### PR TITLE
MET-2727: Add portalUrl when workflow execution is done

### DIFF
--- a/src/main/java/eu/europeana/metis/sandbox/dto/DatasetInfoDto.java
+++ b/src/main/java/eu/europeana/metis/sandbox/dto/DatasetInfoDto.java
@@ -28,38 +28,44 @@ public class DatasetInfoDto {
     }
   }
 
+  private final String portalUrl;
+
   private final Status status;
 
   @JsonProperty("total-records")
-  private final Long totalRecords;
+  private final long totalRecords;
 
   @JsonProperty("processed-records")
-  private final Long processedRecords;
+  private final long processedRecords;
 
   @JsonProperty("progress-by-step")
   private final List<ProgressByStepDto> progressByStep;
 
-  public DatasetInfoDto(Integer totalRecords,
-      Long processedRecords, List<ProgressByStepDto> progressByStep) {
-    requireNonNull(totalRecords, "Total records must not be null");
-    requireNonNull(processedRecords, "Processed records must not be null");
+  public DatasetInfoDto(String portalUrl, int totalRecords,
+      long processedRecords, List<ProgressByStepDto> progressByStep) {
+    requireNonNull(portalUrl, "Portal url must not be null");
     requireNonNull(progressByStep, "Progress by step must not be null");
-    this.totalRecords = Long.valueOf(totalRecords);
-    this.status =
-        this.totalRecords.equals(processedRecords) ? Status.COMPLETED : Status.IN_PROGRESS;
+    this.totalRecords = totalRecords;
     this.processedRecords = processedRecords;
+    this.status =
+        this.totalRecords == this.processedRecords ? Status.COMPLETED : Status.IN_PROGRESS;
     this.progressByStep = Collections.unmodifiableList(progressByStep);
+    this.portalUrl = portalUrl;
+  }
+
+  public String getPortalUrl() {
+    return portalUrl;
   }
 
   public Status getStatus() {
     return status;
   }
 
-  public Long getTotalRecords() {
+  public long getTotalRecords() {
     return totalRecords;
   }
 
-  public Long getProcessedRecords() {
+  public long getProcessedRecords() {
     return processedRecords;
   }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -99,6 +99,8 @@ sandbox:
         default:
           collection:
         timeout:
+  portal:
+    url:
   rabbitmq:
     routing-key:
       closed: sandbox.record.closed

--- a/src/test/java/eu/europeana/metis/sandbox/controller/DatasetControllerTest.java
+++ b/src/test/java/eu/europeana/metis/sandbox/controller/DatasetControllerTest.java
@@ -179,7 +179,7 @@ class DatasetControllerTest {
     var errors = List.of(error1, error2);
     var createProgress = new ProgressByStepDto(Step.CREATE, 10, 0, 0, List.of());
     var externalProgress = new ProgressByStepDto(Step.VALIDATE_EXTERNAL, 7, 3, 0, errors);
-    var report = new DatasetInfoDto(10, 10L, List.of(createProgress, externalProgress));
+    var report = new DatasetInfoDto("https://metis-sandbox", 10, 10L, List.of(createProgress, externalProgress));
     when(datasetReportService.getReport("1")).thenReturn(report);
 
     mvc.perform(get("/dataset/{id}", "1"))

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -58,6 +58,8 @@ sandbox:
       ports: 27017
     solr:
       hosts: http://metis-test:8888/solr/metis_sandbox_test
+  portal:
+    url: http://metis-test
   truststore:
     path:
     password:


### PR DESCRIPTION
Looks like this

```json
{
  "portalUrl": "https://metis-sandbox-preview-api-test-portal.eanadev.org/portal/search?view=grid&q=edm_datasetName:12_test*",
  "status": "completed",
  "total-records": 232,
  "processed-records": 232,
  "progress-by-step": [
    {
      "step": "import",
      "total": 232,
      "success": 232,
...
```