### PR TITLE
MET-4106 Update log4j version 2.17.1 that fix CVE-2021-44832

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,8 +49,6 @@
     <version.coveralls>4.0.0</version.coveralls>
     <version.surefire.plugin>2.22.1</version.surefire.plugin>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <version.slf4j>1.7.30</version.slf4j>
-    <version.log4j>2.17.1</version.log4j>
   </properties>
 
   <dependencies>
@@ -90,6 +88,12 @@
       <groupId>eu.europeana.metis</groupId>
       <artifactId>metis-harvesting</artifactId>
       <version>${version.metis}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.logging.log4j</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>
@@ -135,32 +139,23 @@
       <groupId>eu.europeana.metis</groupId>
       <artifactId>metis-indexing</artifactId>
       <version>${version.metis}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.logging.log4j</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
-    <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-api</artifactId>
-      <version>${version.log4j}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-core</artifactId>
-      <version>${version.log4j}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-slf4j-impl</artifactId>
-      <version>${version.log4j}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-      <version>${version.slf4j}</version>
-    </dependency>
+
     <dependency>
       <groupId>eu.europeana.corelib</groupId>
       <artifactId>corelib-web</artifactId>
       <version>${version.europeana}</version>
       <exclusions>
+        <exclusion>
+          <groupId>org.apache.logging.log4j</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
         <exclusion>
           <groupId>org.mockito</groupId>
           <artifactId>mockito-all</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -42,13 +42,15 @@
     <version.java>11</version.java>
     <version.springfox>2.9.2</version.springfox>
     <version.metis>6-SNAPSHOT</version.metis>
-    <version.europeana>2.14.1-SNAPSHOT</version.europeana>
+    <version.europeana>2.15.3</version.europeana>
     <version.postgresql>42.2.11</version.postgresql>
     <version.aws.s3>1.11.762</version.aws.s3>
     <version.maven.compiler.plugin>3.6.1</version.maven.compiler.plugin>
     <version.coveralls>4.0.0</version.coveralls>
     <version.surefire.plugin>2.22.1</version.surefire.plugin>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <version.slf4j>1.7.30</version.slf4j>
+    <version.log4j>2.17.1</version.log4j>
   </properties>
 
   <dependencies>
@@ -134,16 +136,31 @@
       <artifactId>metis-indexing</artifactId>
       <version>${version.metis}</version>
     </dependency>
-
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-api</artifactId>
+      <version>${version.log4j}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+      <version>${version.log4j}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-slf4j-impl</artifactId>
+      <version>${version.log4j}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>${version.slf4j}</version>
+    </dependency>
     <dependency>
       <groupId>eu.europeana.corelib</groupId>
       <artifactId>corelib-web</artifactId>
       <version>${version.europeana}</version>
       <exclusions>
-        <exclusion>
-          <groupId>org.apache.logging.log4j</groupId>
-          <artifactId>log4j-slf4j-impl</artifactId>
-        </exclusion>
         <exclusion>
           <groupId>org.mockito</groupId>
           <artifactId>mockito-all</artifactId>


### PR DESCRIPTION
Update log4j version from 2.17.0 to 2.17.1 to fix CVE-2021-44832