### PR TITLE
Bug/met 4183 out of memory findings and corrections

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,7 @@
     <version.slf4j>1.7.30</version.slf4j>
     <version.log4j>2.17.1</version.log4j>
     <version.logcaptor>2.7.8</version.logcaptor>
+    <version.wiremock>2.32.0</version.wiremock>
   </properties>
 
   <dependencies>
@@ -234,6 +235,18 @@
       <version>1.0.14</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>io.github.hakky54</groupId>
+      <artifactId>logcaptor</artifactId>
+      <version>${version.logcaptor}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.github.tomakehurst</groupId>
+      <artifactId>wiremock-jre8</artifactId>
+      <version>${version.wiremock}</version>
+      <scope>test</scope>
+    </dependency>
 
     <!-- Swagger -->
     <dependency>
@@ -245,12 +258,6 @@
       <groupId>io.springfox</groupId>
       <artifactId>springfox-swagger-ui</artifactId>
       <version>${version.springfox}</version>
-    </dependency>
-    <dependency>
-      <groupId>io.github.hakky54</groupId>
-      <artifactId>logcaptor</artifactId>
-      <version>${version.logcaptor}</version>
-      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <version.slf4j>1.7.30</version.slf4j>
     <version.log4j>2.17.1</version.log4j>
+    <version.logcaptor>2.7.8</version.logcaptor>
   </properties>
 
   <dependencies>
@@ -191,7 +192,6 @@
       <artifactId>log4j-core</artifactId>
       <version>${version.log4j}</version>
     </dependency>
-
     <!-- Persistence -->
     <dependency>
       <groupId>com.h2database</groupId>
@@ -246,6 +246,12 @@
       <artifactId>springfox-swagger-ui</artifactId>
       <version>${version.springfox}</version>
     </dependency>
+    <dependency>
+      <groupId>io.github.hakky54</groupId>
+      <artifactId>logcaptor</artifactId>
+      <version>${version.logcaptor}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <repositories>
@@ -289,6 +295,11 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <version>${version.surefire.plugin}</version>
+        <configuration>
+          <classpathDependencyExcludes>
+            <classpathDependencyExclude>org.apache.logging.log4j:log4j-slf4j-impl</classpathDependencyExclude>
+          </classpathDependencyExcludes>
+        </configuration>
         <executions>
           <execution>
             <id>unit-tests</id>

--- a/src/main/java/eu/europeana/metis/sandbox/config/amqp/RecordLogConfiguration.java
+++ b/src/main/java/eu/europeana/metis/sandbox/config/amqp/RecordLogConfiguration.java
@@ -13,8 +13,8 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 /**
- * Config for record log. This binds an exchange with a queue using a routing key that listens for
- * all messages traveling through the message broker
+ * Config for record log. This binds an exchange with a queue using a routing key that listens for all messages traveling through
+ * the message broker
  */
 @Configuration
 class RecordLogConfiguration {
@@ -31,11 +31,14 @@ class RecordLogConfiguration {
   @Value("${sandbox.rabbitmq.queues.record.log.routing-key}")
   private String routingKey;
 
-  @Value("${sandbox.rabbitmq.queues.record.log.consumers}")
+  @Value("${sandbox.rabbitmq.queues.record.log.consumers:2}")
   private int consumers;
 
-  @Value("${sandbox.rabbitmq.queues.record.log.max-consumers}")
+  @Value("${sandbox.rabbitmq.queues.record.log.max-consumers:2}")
   private int maxConsumers;
+
+  @Value("${sandbox.rabbitmq.queues.record.log.prefetch:1}")
+  private int prefetchCount;
 
   private final MessageConverter messageConverter;
 
@@ -50,8 +53,10 @@ class RecordLogConfiguration {
 
   @Bean
   Queue logQueue() {
-    return QueueBuilder.durable(queue).deadLetterExchange(exchangeDlq).deadLetterRoutingKey(dlq)
-        .build();
+    return QueueBuilder.durable(queue)
+                       .deadLetterExchange(exchangeDlq)
+                       .deadLetterRoutingKey(dlq)
+                       .build();
   }
 
   @Bean
@@ -61,12 +66,16 @@ class RecordLogConfiguration {
 
   @Bean
   Binding logBinding() {
-    return BindingBuilder.bind(logQueue()).to(amqpConfiguration.exchange()).with(routingKey);
+    return BindingBuilder.bind(logQueue())
+                         .to(amqpConfiguration.exchange())
+                         .with(routingKey);
   }
 
   @Bean
   Binding logDlqBinding() {
-    return BindingBuilder.bind(logDlq()).to(amqpConfiguration.dlqExchange()).with(dlq);
+    return BindingBuilder.bind(logDlq())
+                         .to(amqpConfiguration.dlqExchange())
+                         .with(dlq);
   }
 
   // By having a factory defined for each consumer we can tune specific settings if we need to
@@ -79,6 +88,7 @@ class RecordLogConfiguration {
     factory.setMessageConverter(messageConverter);
     factory.setConcurrentConsumers(consumers);
     factory.setMaxConcurrentConsumers(maxConsumers);
+    factory.setPrefetchCount(prefetchCount);
     return factory;
   }
 }

--- a/src/main/java/eu/europeana/metis/sandbox/config/amqp/WorkflowListenerConfig.java
+++ b/src/main/java/eu/europeana/metis/sandbox/config/amqp/WorkflowListenerConfig.java
@@ -3,18 +3,23 @@ package eu.europeana.metis.sandbox.config.amqp;
 import org.springframework.amqp.rabbit.config.SimpleRabbitListenerContainerFactory;
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
 import org.springframework.amqp.support.converter.MessageConverter;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.amqp.SimpleRabbitListenerContainerFactoryConfigurer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 /**
- * Config for workflow listeners. Every listener has a {@link SimpleRabbitListenerContainerFactory}.
- * <br /><br />
- * If changes like increasing consumers for a listener are needed, here is the place to do it, by using the
- * SimpleRabbitListenerContainerFactory
+ * Config for workflow listeners. Every listener has a {@link SimpleRabbitListenerContainerFactory}. <br /><br /> If changes like
+ * increasing consumers for a listener are needed, here is the place to do it, by using the SimpleRabbitListenerContainerFactory
  */
 @Configuration
 class WorkflowListenerConfig {
+
+  @Value("${sandbox.rabbitmq.concurrent.queues.consumers:2}")
+  private int concurrentQueueConsumers;
+
+  @Value("${sandbox.rabbitmq.max.concurrent.queues.consumers:8}")
+  private int maxConcurrentQueueConsumers;
 
   private final MessageConverter messageConverter;
 
@@ -91,6 +96,8 @@ class WorkflowListenerConfig {
       ConnectionFactory connectionFactory) {
     var factory = new SimpleRabbitListenerContainerFactory();
     configurer.configure(factory, connectionFactory);
+    factory.setConcurrentConsumers(concurrentQueueConsumers);
+    factory.setMaxConcurrentConsumers(maxConcurrentQueueConsumers);
     factory.setMessageConverter(messageConverter);
     return factory;
   }

--- a/src/main/java/eu/europeana/metis/sandbox/config/amqp/WorkflowListenerConfig.java
+++ b/src/main/java/eu/europeana/metis/sandbox/config/amqp/WorkflowListenerConfig.java
@@ -15,11 +15,14 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 class WorkflowListenerConfig {
 
-  @Value("${sandbox.rabbitmq.concurrent.queues.consumers:2}")
+  @Value("${spring.rabbitmq.listener.simple.concurrency:2}")
   private int concurrentQueueConsumers;
 
-  @Value("${sandbox.rabbitmq.max.concurrent.queues.consumers:8}")
+  @Value("${spring.rabbitmq.listener.simple.max-concurrency:2}")
   private int maxConcurrentQueueConsumers;
+
+  @Value("${spring.rabbitmq.listener.prefetch:1}")
+  private int prefetchCount;
 
   private final MessageConverter messageConverter;
 
@@ -98,6 +101,7 @@ class WorkflowListenerConfig {
     configurer.configure(factory, connectionFactory);
     factory.setConcurrentConsumers(concurrentQueueConsumers);
     factory.setMaxConcurrentConsumers(maxConcurrentQueueConsumers);
+    factory.setPrefetchCount(prefetchCount);
     factory.setMessageConverter(messageConverter);
     return factory;
   }

--- a/src/main/java/eu/europeana/metis/sandbox/executor/workflow/CloseExecutor.java
+++ b/src/main/java/eu/europeana/metis/sandbox/executor/workflow/CloseExecutor.java
@@ -4,6 +4,8 @@ import eu.europeana.metis.sandbox.common.Status;
 import eu.europeana.metis.sandbox.common.Step;
 import eu.europeana.metis.sandbox.domain.Event;
 import eu.europeana.metis.sandbox.domain.RecordInfo;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.amqp.core.AmqpTemplate;
 import org.springframework.amqp.rabbit.annotation.RabbitListener;
 import org.springframework.beans.factory.annotation.Value;
@@ -15,6 +17,7 @@ import org.springframework.stereotype.Component;
 @Component
 class CloseExecutor {
 
+  private static final Logger LOGGER = LoggerFactory.getLogger(CloseExecutor.class);
   private final AmqpTemplate amqpTemplate;
 
   @Value("${sandbox.rabbitmq.routing-key.closed}")
@@ -31,8 +34,11 @@ class CloseExecutor {
     if (input.getStatus() == Status.FAIL) {
       return;
     }
-
-    Event output = new Event(new RecordInfo(input.getBody()), Step.CLOSE, Status.SUCCESS);
-    amqpTemplate.convertAndSend(routingKey, output);
+    try {
+      Event output = new Event(new RecordInfo(input.getBody()), Step.CLOSE, Status.SUCCESS);
+      amqpTemplate.convertAndSend(routingKey, output);
+    } catch (RuntimeException closeException) {
+      LOGGER.error("Close executor error", closeException);
+    }
   }
 }

--- a/src/main/java/eu/europeana/metis/sandbox/executor/workflow/StepExecutor.java
+++ b/src/main/java/eu/europeana/metis/sandbox/executor/workflow/StepExecutor.java
@@ -10,7 +10,6 @@ import java.util.List;
 import java.util.function.Supplier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.amqp.AmqpException;
 import org.springframework.amqp.core.AmqpTemplate;
 
 /**
@@ -45,7 +44,7 @@ class StepExecutor {
     try {
       amqpTemplate.convertAndSend(routingKey, output);
     } catch (RuntimeException rabbitException) {
-      logger.error("Step execution error", rabbitException);
+      logger.error("Queue step execution error", rabbitException);
     }
   }
 
@@ -53,8 +52,7 @@ class StepExecutor {
     Event output;
     logger.error("Exception while performing step: [{}]. ", step.value(), ex);
     var recordError = new RecordError(ex);
-    output = new Event(new RecordInfo(input.getBody(), List.of(recordError)),
-        step, Status.FAIL);
+    output = new Event(new RecordInfo(input.getBody(), List.of(recordError)), step, Status.FAIL);
     return output;
   }
 }

--- a/src/main/java/eu/europeana/metis/sandbox/executor/workflow/StepExecutor.java
+++ b/src/main/java/eu/europeana/metis/sandbox/executor/workflow/StepExecutor.java
@@ -49,10 +49,10 @@ class StepExecutor {
   }
 
   private Event createFailEvent(Event input, Step step, RecordProcessingException ex) {
-    Event output;
-    LOGGER.error("Exception while performing step: [{}]. ", step.value(), ex);
-    var recordError = new RecordError(ex);
-    output = new Event(new RecordInfo(input.getBody(), List.of(recordError)), step, Status.FAIL);
+    final String stepName = step.value();
+    final RecordError recordError = new RecordError(ex);
+    final Event output = new Event(new RecordInfo(input.getBody(), List.of(recordError)), step, Status.FAIL);
+    LOGGER.error("Exception while performing step: [{}]. ", stepName, ex);
     return output;
   }
 }

--- a/src/main/java/eu/europeana/metis/sandbox/executor/workflow/StepExecutor.java
+++ b/src/main/java/eu/europeana/metis/sandbox/executor/workflow/StepExecutor.java
@@ -17,7 +17,7 @@ import org.springframework.amqp.core.AmqpTemplate;
  */
 class StepExecutor {
 
-  private final Logger logger = LoggerFactory.getLogger(this.getClass());
+  private static final Logger LOGGER = LoggerFactory.getLogger(StepExecutor.class);
   private final AmqpTemplate amqpTemplate;
 
   StepExecutor(AmqpTemplate amqpTemplate) {
@@ -44,13 +44,13 @@ class StepExecutor {
     try {
       amqpTemplate.convertAndSend(routingKey, output);
     } catch (RuntimeException rabbitException) {
-      logger.error("Queue step execution error", rabbitException);
+      LOGGER.error("Queue step execution error", rabbitException);
     }
   }
 
   private Event createFailEvent(Event input, Step step, RecordProcessingException ex) {
     Event output;
-    logger.error("Exception while performing step: [{}]. ", step.value(), ex);
+    LOGGER.error("Exception while performing step: [{}]. ", step.value(), ex);
     var recordError = new RecordError(ex);
     output = new Event(new RecordInfo(input.getBody(), List.of(recordError)), step, Status.FAIL);
     return output;

--- a/src/main/java/eu/europeana/metis/sandbox/service/dataset/AsyncDatasetPublishServiceImpl.java
+++ b/src/main/java/eu/europeana/metis/sandbox/service/dataset/AsyncDatasetPublishServiceImpl.java
@@ -32,7 +32,8 @@ class AsyncDatasetPublishServiceImpl implements AsyncDatasetPublishService {
     private final Executor asyncDatasetPublishServiceTaskExecutor;
 
     public AsyncDatasetPublishServiceImpl(AmqpTemplate amqpTemplate,
-                                          String createdQueue, String transformationToEdmExternalQueue,
+                                          String createdQueue,
+                                          String transformationToEdmExternalQueue,
                                           Executor asyncDatasetPublishServiceTaskExecutor) {
         this.amqpTemplate = amqpTemplate;
         this.createdQueue = createdQueue;

--- a/src/main/java/eu/europeana/metis/sandbox/service/dataset/DatasetRemoverServiceImpl.java
+++ b/src/main/java/eu/europeana/metis/sandbox/service/dataset/DatasetRemoverServiceImpl.java
@@ -32,26 +32,30 @@ class DatasetRemoverServiceImpl implements DatasetRemoverService {
 
   @Override
   public void remove(int days) {
-    // get old dataset ids
-    List<String> datasets = datasetService.getDatasetIdsCreatedBefore(days);
+    try {
+      // get old dataset ids
+      List<String> datasets = datasetService.getDatasetIdsCreatedBefore(days);
 
-    LOGGER.info("Datasets to remove {} ", datasets);
+      LOGGER.info("Datasets to remove {} ", datasets);
 
-    datasets.forEach(dataset -> {
-      try {
-        // remove thumbnails (s3)
-        LOGGER.debug("Remove thumbnails for dataset id: [{}]", dataset);
-        thumbnailStoreService.remove(dataset);
-        // remove from mongo and solr
-        LOGGER.debug("Remove index for dataset id: [{}]", dataset);
-        indexingService.remove(dataset);
-        // remove from sandbox
-        LOGGER.debug("Remove record logs for dataset id: [{}]", dataset);
-        recordLogService.remove(dataset);
-        datasetService.remove(dataset);
-      } catch (ServiceException e) {
-        LOGGER.error("Failed to remove dataset [{}] ", dataset, e);
-      }
-    });
+      datasets.forEach(dataset -> {
+        try {
+          // remove thumbnails (s3)
+          LOGGER.debug("Remove thumbnails for dataset id: [{}]", dataset);
+          thumbnailStoreService.remove(dataset);
+          // remove from mongo and solr
+          LOGGER.debug("Remove index for dataset id: [{}]", dataset);
+          indexingService.remove(dataset);
+          // remove from sandbox
+          LOGGER.debug("Remove record logs for dataset id: [{}]", dataset);
+          recordLogService.remove(dataset);
+          datasetService.remove(dataset);
+        } catch (ServiceException e) {
+          LOGGER.error("Failed to remove dataset [{}] ", dataset, e);
+        }
+      });
+    } catch (RuntimeException exception) {
+      LOGGER.error("General failure to remove dataset", exception);
+    }
   }
 }

--- a/src/main/java/eu/europeana/metis/sandbox/service/util/XsltUrlUpdateServiceImpl.java
+++ b/src/main/java/eu/europeana/metis/sandbox/service/util/XsltUrlUpdateServiceImpl.java
@@ -41,6 +41,7 @@ public class XsltUrlUpdateServiceImpl implements XsltUrlUpdateService {
     } catch (IOException | InterruptedException e) {
       // try to load resource as file
       xsltStream = getClass().getClassLoader().getResourceAsStream(defaultXsltUrl);
+      Thread.currentThread().interrupt();
     } catch (Exception e) {
       LOGGER.warn("Error getting default transform XSLT ", e);
     } finally {
@@ -53,8 +54,8 @@ public class XsltUrlUpdateServiceImpl implements XsltUrlUpdateService {
 
   private void saveDefaultXslt(InputStream xsltStream) {
     try {
-      String transformXslt = new String(xsltStream.readAllBytes(), StandardCharsets.UTF_8);
-      var entity = transformXsltRepository.findById(1);
+      final String transformXslt = new String(xsltStream.readAllBytes(), StandardCharsets.UTF_8);
+      final var entity = transformXsltRepository.findById(1);
 
       if (entity.isPresent()) {
         if (!(transformXslt.equals(entity.get().getTransformXslt()))) {
@@ -64,7 +65,7 @@ public class XsltUrlUpdateServiceImpl implements XsltUrlUpdateService {
       } else {
         transformXsltRepository.save(new TransformXsltEntity(transformXslt));
       }
-    } catch (IOException e) {
+    } catch (RuntimeException | IOException e) {
       LOGGER.warn("Error persisting default transform XSLT to Database", e);
     }
   }

--- a/src/main/java/eu/europeana/metis/sandbox/service/util/XsltUrlUpdateServiceImpl.java
+++ b/src/main/java/eu/europeana/metis/sandbox/service/util/XsltUrlUpdateServiceImpl.java
@@ -2,6 +2,7 @@ package eu.europeana.metis.sandbox.service.util;
 
 import eu.europeana.metis.sandbox.entity.TransformXsltEntity;
 import eu.europeana.metis.sandbox.repository.TransformXsltRepository;
+import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
@@ -31,9 +32,9 @@ public class XsltUrlUpdateServiceImpl implements XsltUrlUpdateService {
     HttpRequest httpRequest;
     try {
       httpRequest = HttpRequest.newBuilder()
-          .GET()
-          .uri(URI.create(defaultXsltUrl))
-          .build();
+                               .GET()
+                               .uri(URI.create(defaultXsltUrl))
+                               .build();
 
       xsltStream = httpClient.send(httpRequest, BodyHandlers.ofInputStream()).body();
 
@@ -42,9 +43,11 @@ public class XsltUrlUpdateServiceImpl implements XsltUrlUpdateService {
       xsltStream = getClass().getClassLoader().getResourceAsStream(defaultXsltUrl);
     } catch (Exception e) {
       LOGGER.warn("Error getting default transform XSLT ", e);
-    }
-    if (xsltStream != null) {
-      saveDefaultXslt(xsltStream);
+    } finally {
+      if (xsltStream != null) {
+        saveDefaultXslt(xsltStream);
+        closeStream(xsltStream);
+      }
     }
   }
 
@@ -63,6 +66,16 @@ public class XsltUrlUpdateServiceImpl implements XsltUrlUpdateService {
       }
     } catch (IOException e) {
       LOGGER.warn("Error persisting default transform XSLT to Database", e);
+    }
+  }
+
+  private void closeStream(Closeable closeable) {
+    if (closeable != null) {
+      try {
+        closeable.close();
+      } catch (IOException e) {
+        LOGGER.error("Unable to close stream transform XSLT", e);
+      }
     }
   }
 }

--- a/src/main/java/eu/europeana/metis/sandbox/service/workflow/HarvestServiceImpl.java
+++ b/src/main/java/eu/europeana/metis/sandbox/service/workflow/HarvestServiceImpl.java
@@ -92,7 +92,7 @@ public class HarvestServiceImpl implements HarvestService {
       recordHeaderIterator.forEach(recordHeader -> {
         currentNumberOfIterations.getAndIncrement();
 
-        if(currentNumberOfIterations.get() > maxRecords){
+        if (currentNumberOfIterations.get() > maxRecords) {
           hasReachedRecordLimit.set(true);
           return IterationResult.TERMINATE;
         }
@@ -117,7 +117,7 @@ public class HarvestServiceImpl implements HarvestService {
     if (records.isEmpty()) {
       throw new ServiceException("Error records are empty ", null);
     }
-    return new HarvestContent(hasReachedRecordLimit,records);
+    return new HarvestContent(hasReachedRecordLimit, records);
   }
 
   private HarvestContent harvest(InputStream inputStream) throws ServiceException {
@@ -129,7 +129,7 @@ public class HarvestServiceImpl implements HarvestService {
     try {
       harvester.harvestRecords(inputStream, CompressedFileExtension.ZIP, entry -> {
         numberOfIterations.getAndIncrement();
-        if(numberOfIterations.get() > maxRecords){
+        if (numberOfIterations.get() > maxRecords) {
           hasReachedRecordLimit.set(true);
         } else {
           final byte[] content = entry.getEntryContent().readAllBytes();
@@ -139,12 +139,18 @@ public class HarvestServiceImpl implements HarvestService {
 
     } catch (HarvesterException e) {
       throw new ServiceException("Error harvesting records ", e);
+    } finally {
+      try {
+        inputStream.close();
+      } catch (IOException e) {
+        throw new ServiceException("Unable to close harvest stream", e);
+      }
     }
 
     if (records.isEmpty()) {
       throw new ServiceException("Provided file does not contain any records", null);
     }
-    return new HarvestContent(hasReachedRecordLimit,records);
+    return new HarvestContent(hasReachedRecordLimit, records);
   }
 
 }

--- a/src/main/java/eu/europeana/metis/sandbox/service/workflow/MediaProcessingServiceImpl.java
+++ b/src/main/java/eu/europeana/metis/sandbox/service/workflow/MediaProcessingServiceImpl.java
@@ -79,8 +79,8 @@ class MediaProcessingServiceImpl implements MediaProcessingService {
     }
 
     // Get output rdf bytes
-    var rdfSerializer = converterFactory.createRdfSerializer();
-    byte[] outputRdf = getOutputRdf(record, rdfSerializer, rdfForEnrichment);
+    final RdfSerializer rdfSerializer = converterFactory.createRdfSerializer();
+    final byte[] outputRdf = getOutputRdf(record, rdfSerializer, rdfForEnrichment);
 
     return new RecordInfo(Record.from(record, outputRdf), recordErrors);
   }
@@ -92,12 +92,12 @@ class MediaProcessingServiceImpl implements MediaProcessingService {
    */
   private boolean processResource(RdfResourceEntry resourceToProcess, Record record,
       EnrichedRdf rdfForEnrichment, MediaExtractor extractor, List<RecordError> recordErrors,
-      boolean gotMainThumbnail){
+      boolean gotMainThumbnail) {
 
     ResourceExtractionResult extraction;
     boolean successful = false;
 
-    try{
+    try {
       // Perform media extraction
       extraction = extractor.performMediaExtraction(resourceToProcess, gotMainThumbnail);
 
@@ -105,14 +105,14 @@ class MediaProcessingServiceImpl implements MediaProcessingService {
       successful = extraction != null;
 
       // If successful then store data
-      if(successful){
+      if (successful) {
         rdfForEnrichment.enrichResource(extraction.getMetadata());
-        if(!CollectionUtils.isEmpty(extraction.getThumbnails())) {
+        if (!CollectionUtils.isEmpty(extraction.getThumbnails())) {
           storeThumbnails(record, extraction.getThumbnails(), recordErrors);
         }
       }
 
-    } catch(MediaExtractionException e) {
+    } catch (MediaExtractionException e) {
       LOGGER.warn("Error while extracting media for record {}. ", record.getProviderId(), e);
       // collect warnings
       recordErrors.add(new RecordError(new RecordProcessingException(record.getProviderId(), e)));

--- a/src/main/java/eu/europeana/metis/sandbox/service/workflow/NormalizationServiceImpl.java
+++ b/src/main/java/eu/europeana/metis/sandbox/service/workflow/NormalizationServiceImpl.java
@@ -24,8 +24,8 @@ class NormalizationServiceImpl implements NormalizationService {
   public RecordInfo normalize(Record record) {
     requireNonNull(record, "Record must not be null");
 
-    Normalizer normalizer;
-    byte[] result;
+    final Normalizer normalizer;
+    final byte[] result;
     try {
       normalizer = normalizerFactory.getNormalizer();
       result = normalizer.normalize(record.getContentInputStream());

--- a/src/main/java/eu/europeana/metis/sandbox/service/workflow/TransformationServiceImpl.java
+++ b/src/main/java/eu/europeana/metis/sandbox/service/workflow/TransformationServiceImpl.java
@@ -33,7 +33,7 @@ class TransformationServiceImpl implements TransformationService {
   public RecordInfo transformToEdmInternal(Record record) {
     requireNonNull(record, "Record must not be null");
 
-    byte[] recordTransformed;
+    final byte[] recordTransformed;
     try {
       final EuropeanaGeneratedIdsMap europeanaGeneratedIdsMap = new EuropeanaIdCreator()
           .constructEuropeanaId(record.getContentInputStream(), record.getDatasetId());
@@ -61,7 +61,7 @@ class TransformationServiceImpl implements TransformationService {
   public byte[] transform(String identifier, InputStream xsltContentInputStream,
       byte[] recordContent) {
 
-    byte[] resultRecord;
+    final byte[] resultRecord;
     try {
       XsltTransformer transformer = getNewTransformerObject(identifier, xsltContentInputStream);
       resultRecord = transformer.transformToBytes(recordContent, null);
@@ -76,7 +76,7 @@ class TransformationServiceImpl implements TransformationService {
       String edmLanguage) throws TransformationException {
 
     var xsltTransformEntity = transformXsltRepository.findById(1);
-    String xsltTransform;
+    final String xsltTransform;
     InputStream xsltInputStream = null;
     if (xsltTransformEntity.isPresent()) {
       xsltTransform = xsltTransformEntity.get().getTransformXslt();

--- a/src/main/java/eu/europeana/metis/sandbox/service/workflow/TransformationServiceImpl.java
+++ b/src/main/java/eu/europeana/metis/sandbox/service/workflow/TransformationServiceImpl.java
@@ -13,6 +13,7 @@ import eu.europeana.metis.transformation.service.EuropeanaIdException;
 import eu.europeana.metis.transformation.service.TransformationException;
 import eu.europeana.metis.transformation.service.XsltTransformer;
 import java.io.ByteArrayInputStream;
+import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import org.springframework.stereotype.Service;
@@ -67,6 +68,12 @@ class TransformationServiceImpl implements TransformationService {
       resultRecord = transformer.transformToBytes(recordContent, null);
     } catch (TransformationException e) {
       throw new RecordProcessingException(identifier, e);
+    } finally {
+      try {
+        xsltContentInputStream.close();
+      } catch (IOException e) {
+        throw new RecordProcessingException(identifier, e);
+      }
     }
 
     return resultRecord;

--- a/src/main/resources/sample.application.yml
+++ b/src/main/resources/sample.application.yml
@@ -123,8 +123,8 @@ sandbox:
           dlq: ${sandbox.rabbitmq.queues.record.log.queue}.dlq
           routing-key: sandbox.record.#
           auto-start: true
-          consumers: 20
-          max-consumers: 40
+          consumers: 2
+          max-consumers: 2
         created:
           queue: sandbox.record.created
           dlq: ${sandbox.rabbitmq.queues.record.created.queue}.dlq

--- a/src/main/resources/sample.application.yml
+++ b/src/main/resources/sample.application.yml
@@ -30,8 +30,8 @@ spring:
       algorithm:
     listener:
       simple:
-        concurrency: 5
-        max-concurrency: 10
+        concurrency: 2
+        max-concurrency: 2
         prefetch: 1
         retry:
           enabled: true

--- a/src/test/java/eu/europeana/metis/sandbox/executor/workflow/CloseExecutorTest.java
+++ b/src/test/java/eu/europeana/metis/sandbox/executor/workflow/CloseExecutorTest.java
@@ -1,7 +1,9 @@
 package eu.europeana.metis.sandbox.executor.workflow;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
@@ -12,6 +14,7 @@ import eu.europeana.metis.sandbox.common.locale.Language;
 import eu.europeana.metis.sandbox.domain.Event;
 import eu.europeana.metis.sandbox.domain.Record;
 import eu.europeana.metis.sandbox.domain.RecordInfo;
+import nl.altindag.log.LogCaptor;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -19,6 +22,7 @@ import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.amqp.AmqpException;
 import org.springframework.amqp.core.AmqpTemplate;
 
 @ExtendWith(MockitoExtension.class)
@@ -35,10 +39,7 @@ class CloseExecutorTest {
 
   @Test
   void close_expectSuccess() {
-    var record = Record.builder()
-        .datasetId("").datasetName("").country(Country.ITALY).language(Language.IT)
-        .content("".getBytes())
-        .recordId(1L).build();
+    var record = getTestRecord();
     var recordEvent = new Event(new RecordInfo(record), Step.CREATE, Status.SUCCESS);
 
     consumer.close(recordEvent);
@@ -50,14 +51,39 @@ class CloseExecutorTest {
 
   @Test
   void close_inputMessageWithFailStatus_expectNoInteractions() {
-    var record = Record.builder()
-        .datasetId("").datasetName("").country(Country.ITALY).language(Language.IT)
-        .content("".getBytes())
-        .recordId(1L).build();
+    var record = getTestRecord();
     var recordEvent = new Event(new RecordInfo(record), Step.CREATE, Status.FAIL);
 
     consumer.close(recordEvent);
 
     verify(amqpTemplate, never()).convertAndSend(any(), any(Event.class));
+  }
+
+  @Test
+  void close_exception_expectLogError() {
+    final LogCaptor logCaptor = LogCaptor.forClass(CloseExecutor.class);
+    var record = getTestRecord();
+    var recordEvent = new Event(new RecordInfo(record), Step.CREATE, Status.SUCCESS);
+    final RuntimeException runtimeException = new AmqpException("Queue Failure");
+    doThrow(runtimeException)
+        .when(amqpTemplate)
+        .convertAndSend(any(), any(Object.class));
+
+    consumer.close(recordEvent);
+
+    assertLogCaptor(logCaptor);
+  }
+
+  private Record getTestRecord() {
+    return Record.builder()
+                 .datasetId("").datasetName("").country(Country.ITALY).language(Language.IT)
+                 .content("".getBytes())
+                 .recordId(1L).build();
+  }
+
+  private void assertLogCaptor(LogCaptor logCaptor) {
+    assertEquals(1, logCaptor.getErrorLogs().size());
+    final String testMessage = logCaptor.getErrorLogs().stream().findFirst().get();
+    assertTrue(testMessage.contains("Close executor error"));
   }
 }

--- a/src/test/java/eu/europeana/metis/sandbox/executor/workflow/StepExecutorTest.java
+++ b/src/test/java/eu/europeana/metis/sandbox/executor/workflow/StepExecutorTest.java
@@ -1,40 +1,54 @@
 package eu.europeana.metis.sandbox.executor.workflow;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 import eu.europeana.metis.sandbox.common.Status;
 import eu.europeana.metis.sandbox.common.Step;
-import eu.europeana.metis.sandbox.common.amqp.RecordMessageConverter;
+import eu.europeana.metis.sandbox.common.exception.RecordProcessingException;
 import eu.europeana.metis.sandbox.common.locale.Country;
 import eu.europeana.metis.sandbox.common.locale.Language;
 import eu.europeana.metis.sandbox.domain.Event;
 import eu.europeana.metis.sandbox.domain.Record;
 import eu.europeana.metis.sandbox.domain.RecordInfo;
+import nl.altindag.log.LogCaptor;
+import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.exceptions.base.MockitoException;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.amqp.AmqpException;
 import org.springframework.amqp.core.AmqpTemplate;
-import org.springframework.amqp.core.Message;
-import org.springframework.beans.factory.annotation.Autowired;
 
+/**
+ * Unit test for {@link StepExecutor}
+ * @author Jorge Ortiz
+ */
+@ExtendWith(MockitoExtension.class)
 class StepExecutorTest {
 
   @Mock
   private AmqpTemplate amqpTemplate;
+
   @Captor
   private ArgumentCaptor<Event> captor;
 
+  @InjectMocks
+  private StepExecutor stepExecutor;
+
   @Test
-  void consume() {
-    amqpTemplate = mock(AmqpTemplate.class);
-    StepExecutor stepExecutor = new StepExecutor(amqpTemplate);
-    final String routingKey = "routing";
+  void consumeEventStatusSuccess_expectEventSuccess() {
+    final String routingKey = "routingKey";
     final Record myTestRecord = Record.builder().recordId(1L)
                                       .datasetId("1")
                                       .datasetName("")
@@ -44,20 +58,123 @@ class StepExecutorTest {
                                       .build();
     final Event myEvent = new Event(new RecordInfo(myTestRecord), Step.CREATE, Status.SUCCESS);
 
-    stepExecutor.consume(routingKey, myEvent, Step.CREATE, () -> {
-      final Record mySecondRecord = Record.builder().recordId(2L)
-                                          .datasetId("1")
-                                          .datasetName("")
-                                          .country(Country.FINLAND)
-                                          .language(Language.FI)
-                                          .content("".getBytes())
-                                          .build();
-      final RecordInfo recordInfo = new RecordInfo(mySecondRecord);
-      return recordInfo;
-    });
+    stepExecutor.consume(routingKey, myEvent, Step.CREATE, () -> getRecordInfo());
 
-    verify(amqpTemplate).convertAndSend(any(), captor.capture());
+    verify(amqpTemplate).convertAndSend(eq(routingKey), captor.capture());
 
     assertEquals(Step.CREATE, captor.getValue().getStep());
+    assertEquals(getRecordInfo().getRecord().getRecordId(), captor.getValue().getBody().getRecordId());
+    assertEquals(Status.SUCCESS, captor.getValue().getStatus());
+  }
+
+  @Test
+  void consumeEventStatusFailQueueNeverCalled_expectException() {
+    final String routingKey = "routingKey";
+    final Record myTestRecord = Record.builder().recordId(1L)
+                                      .datasetId("1")
+                                      .datasetName("")
+                                      .country(Country.FINLAND)
+                                      .language(Language.FI)
+                                      .content("".getBytes())
+                                      .build();
+    final Event myEvent = new Event(new RecordInfo(myTestRecord), Step.CREATE, Status.FAIL);
+
+    stepExecutor.consume(routingKey, myEvent, Step.CREATE, () -> getRecordInfo());
+
+    verify(amqpTemplate, never()).convertAndSend(eq(routingKey), captor.capture());
+
+    assertThrows(MockitoException.class, () -> captor.getValue());
+  }
+
+  @Test
+  void consumeEventStatusSuccessThrowsRuntimeException_expectEventFail() {
+    final String routingKey = "routingKey";
+    final Long expectedRecordId = 1L;
+    final Record myTestRecord = Record.builder().recordId(expectedRecordId)
+                                      .datasetId("1")
+                                      .datasetName("")
+                                      .country(Country.FINLAND)
+                                      .language(Language.FI)
+                                      .content("".getBytes())
+                                      .build();
+    final Event myEvent = new Event(new RecordInfo(myTestRecord), Step.CREATE, Status.SUCCESS);
+
+    stepExecutor.consume(routingKey, myEvent, Step.CREATE, () ->
+    {
+      throw new RuntimeException("General Failure");
+    });
+
+    verify(amqpTemplate).convertAndSend(eq(routingKey), captor.capture());
+
+    assertEquals(Step.CREATE, captor.getValue().getStep());
+    assertEquals(expectedRecordId, captor.getValue().getBody().getRecordId());
+    assertEquals(Status.FAIL, captor.getValue().getStatus());
+  }
+
+  @Test
+  void consumeEventStatusSuccessThrowsRecordProcessingException_expectEventFail() {
+    final String routingKey = "routingKey";
+    final Long expectedRecordId = 2L;
+    final Record myTestRecord = Record.builder().recordId(expectedRecordId)
+                                      .datasetId("1")
+                                      .datasetName("")
+                                      .country(Country.FINLAND)
+                                      .language(Language.FI)
+                                      .content("".getBytes())
+                                      .build();
+    final Event myEvent = new Event(new RecordInfo(myTestRecord), Step.CREATE, Status.SUCCESS);
+
+    stepExecutor.consume(routingKey, myEvent, Step.CREATE, () ->
+    {
+      throw new RecordProcessingException("2", new Throwable("Record failure"));
+    });
+
+    verify(amqpTemplate).convertAndSend(eq(routingKey), captor.capture());
+
+    assertEquals(Step.CREATE, captor.getValue().getStep());
+    assertEquals(expectedRecordId, captor.getValue().getBody().getRecordId());
+    assertEquals(Status.FAIL, captor.getValue().getStatus());
+  }
+
+  @Test
+  void consumeEventStatusSuccessThrowsRabbitMQException_expectEventSuccess() {
+    final LogCaptor logCaptor = LogCaptor.forClass(StepExecutor.class);
+    final String routingKey = "routingKey";
+    final Long expectedRecordId = 2L;
+    final Record myTestRecord = Record.builder().recordId(expectedRecordId)
+                                      .datasetId("1")
+                                      .datasetName("")
+                                      .country(Country.FINLAND)
+                                      .language(Language.FI)
+                                      .content("".getBytes())
+                                      .build();
+    final Event myEvent = new Event(new RecordInfo(myTestRecord), Step.CREATE, Status.SUCCESS);
+    final RuntimeException runtimeException = new AmqpException("Queue Failure");
+    doThrow(runtimeException)
+        .when(amqpTemplate)
+        .convertAndSend(eq(routingKey), any(Object.class));
+
+    stepExecutor.consume(routingKey, myEvent, Step.CREATE, () -> getRecordInfo());
+
+    assertLogCaptor(logCaptor);
+  }
+
+  private void assertLogCaptor(LogCaptor logCaptor) {
+    assertEquals(1, logCaptor.getErrorLogs().size());
+    final String testMessage = logCaptor.getErrorLogs().stream().findFirst().get();
+    assertTrue( testMessage.contains("Queue step execution error"));
+  }
+
+  @NotNull
+  private RecordInfo getRecordInfo() {
+    final Record mySecondRecord = Record.builder().recordId(2L)
+                                        .datasetId("1")
+                                        .datasetName("")
+                                        .country(Country.FINLAND)
+                                        .language(Language.FI)
+                                        .content("".getBytes())
+                                        .build();
+    final RecordInfo recordInfo = new RecordInfo(mySecondRecord);
+    return recordInfo;
   }
 }

--- a/src/test/java/eu/europeana/metis/sandbox/executor/workflow/StepExecutorTest.java
+++ b/src/test/java/eu/europeana/metis/sandbox/executor/workflow/StepExecutorTest.java
@@ -1,0 +1,63 @@
+package eu.europeana.metis.sandbox.executor.workflow;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import eu.europeana.metis.sandbox.common.Status;
+import eu.europeana.metis.sandbox.common.Step;
+import eu.europeana.metis.sandbox.common.amqp.RecordMessageConverter;
+import eu.europeana.metis.sandbox.common.locale.Country;
+import eu.europeana.metis.sandbox.common.locale.Language;
+import eu.europeana.metis.sandbox.domain.Event;
+import eu.europeana.metis.sandbox.domain.Record;
+import eu.europeana.metis.sandbox.domain.RecordInfo;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.springframework.amqp.core.AmqpTemplate;
+import org.springframework.amqp.core.Message;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class StepExecutorTest {
+
+  @Mock
+  private AmqpTemplate amqpTemplate;
+  @Captor
+  private ArgumentCaptor<Event> captor;
+
+  @Test
+  void consume() {
+    amqpTemplate = mock(AmqpTemplate.class);
+    StepExecutor stepExecutor = new StepExecutor(amqpTemplate);
+    final String routingKey = "routing";
+    final Record myTestRecord = Record.builder().recordId(1L)
+                                      .datasetId("1")
+                                      .datasetName("")
+                                      .country(Country.FINLAND)
+                                      .language(Language.FI)
+                                      .content("".getBytes())
+                                      .build();
+    final Event myEvent = new Event(new RecordInfo(myTestRecord), Step.CREATE, Status.SUCCESS);
+
+    stepExecutor.consume(routingKey, myEvent, Step.CREATE, () -> {
+      final Record mySecondRecord = Record.builder().recordId(2L)
+                                          .datasetId("1")
+                                          .datasetName("")
+                                          .country(Country.FINLAND)
+                                          .language(Language.FI)
+                                          .content("".getBytes())
+                                          .build();
+      final RecordInfo recordInfo = new RecordInfo(mySecondRecord);
+      return recordInfo;
+    });
+
+    verify(amqpTemplate).convertAndSend(any(), captor.capture());
+
+    assertEquals(Step.CREATE, captor.getValue().getStep());
+  }
+}

--- a/src/test/java/eu/europeana/metis/sandbox/service/dataset/DatasetRemoverServiceImplTest.java
+++ b/src/test/java/eu/europeana/metis/sandbox/service/dataset/DatasetRemoverServiceImplTest.java
@@ -1,5 +1,8 @@
 package eu.europeana.metis.sandbox.service.dataset;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.times;
@@ -11,6 +14,7 @@ import eu.europeana.metis.sandbox.service.record.RecordLogService;
 import eu.europeana.metis.sandbox.service.util.ThumbnailStoreService;
 import eu.europeana.metis.sandbox.service.workflow.IndexingService;
 import java.util.List;
+import nl.altindag.log.LogCaptor;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -37,7 +41,8 @@ class DatasetRemoverServiceImplTest {
 
   @Test
   void remove_expectSuccess() {
-    when(datasetService.getDatasetIdsCreatedBefore(7)).thenReturn(List.of("1", "2", "3", "4"));
+    when(datasetService.getDatasetIdsCreatedBefore(7))
+        .thenReturn(List.of("1", "2", "3", "4"));
 
     service.remove(7);
 
@@ -49,8 +54,12 @@ class DatasetRemoverServiceImplTest {
 
   @Test
   void remove_failToRemoveFirstDataset_expectSuccess() {
-    when(datasetService.getDatasetIdsCreatedBefore(7)).thenReturn(List.of("1", "2", "3", "4"));
-    doThrow(new ServiceException("1", new Exception())).when(thumbnailStoreService).remove("1");
+    when(datasetService.getDatasetIdsCreatedBefore(7))
+        .thenReturn(List.of("1", "2", "3", "4"));
+
+    doThrow(new ServiceException("1", new Exception()))
+        .when(thumbnailStoreService)
+        .remove("1");
 
     service.remove(7);
 
@@ -62,8 +71,12 @@ class DatasetRemoverServiceImplTest {
 
   @Test
   void remove_failToRemoveLastDataset_expectSuccess() {
-    when(datasetService.getDatasetIdsCreatedBefore(7)).thenReturn(List.of("1", "2", "3", "4"));
-    doThrow(new ServiceException("4", new Exception())).when(thumbnailStoreService).remove("1");
+    when(datasetService.getDatasetIdsCreatedBefore(7))
+        .thenReturn(List.of("1", "2", "3", "4"));
+
+    doThrow(new ServiceException("4", new Exception()))
+        .when(thumbnailStoreService)
+        .remove("1");
 
     service.remove(7);
 
@@ -71,5 +84,25 @@ class DatasetRemoverServiceImplTest {
     verify(indexingService, times(3)).remove(anyString());
     verify(recordLogService, times(3)).remove(anyString());
     verify(datasetService, times(3)).remove(anyString());
+  }
+
+  @Test
+  void remove_failToRemoveThrowException_expectLogError() {
+    final LogCaptor logCaptor = LogCaptor.forClass(DatasetRemoverServiceImpl.class);
+
+    doThrow(new ServiceException("Error getting ids", new RuntimeException()))
+        .when(datasetService)
+        .getDatasetIdsCreatedBefore(7);
+
+    service.remove(7);
+
+    verify(datasetService, times(1)).getDatasetIdsCreatedBefore(anyInt());
+    assertLogCaptor(logCaptor);
+  }
+
+  private void assertLogCaptor(LogCaptor logCaptor) {
+    assertEquals(1, logCaptor.getErrorLogs().size());
+    final String testMessage = logCaptor.getErrorLogs().stream().findFirst().get();
+    assertTrue(testMessage.contains("General failure to remove dataset"));
   }
 }

--- a/src/test/java/eu/europeana/metis/sandbox/service/util/XsltUrlUpdateServiceImplTest.java
+++ b/src/test/java/eu/europeana/metis/sandbox/service/util/XsltUrlUpdateServiceImplTest.java
@@ -1,35 +1,143 @@
 package eu.europeana.metis.sandbox.service.util;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.when;
 
+import com.github.tomakehurst.wiremock.http.Fault;
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
+import eu.europeana.metis.sandbox.entity.TransformXsltEntity;
 import eu.europeana.metis.sandbox.repository.TransformXsltRepository;
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.util.Optional;
 import nl.altindag.log.LogCaptor;
+import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
+import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-@ExtendWith(MockitoExtension.class)
+@ExtendWith({MockitoExtension.class})
+@TestMethodOrder(OrderAnnotation.class)
 class XsltUrlUpdateServiceImplTest {
 
   @Mock
   private TransformXsltRepository transformXsltRepository;
 
+  @Mock
+  private HttpClient httpClient;
+
   @InjectMocks
   private XsltUrlUpdateServiceImpl xsltUrlUpdateService;
 
+  @RegisterExtension
+  static WireMockExtension wm = WireMockExtension.newInstance()
+                                                 .options(wireMockConfig().port(12345))
+                                                 .proxyMode(true)
+                                                 .build();
+
   @Test
+  @Order(1)
+  void updateXslt_ExpectSuccess() {
+    wm.stubFor(get("/xslt")
+        .withHost(equalTo("document.domain"))
+        .withPort(12345)
+        .willReturn(ok("1")));
+
+    xsltUrlUpdateService.updateXslt("http://document.domain:12345/xlst");
+
+    Mockito.verify(transformXsltRepository, times(1)).save(any());
+  }
+
+  @Test
+  @Order(2)
+  void updateXslt_existent_ExpectSuccess() {
+    wm.stubFor(get("/xslt")
+        .withHost(equalTo("document.domain"))
+        .withPort(12345)
+        .willReturn(ok("1")));
+    when(transformXsltRepository.findById(anyInt())).thenReturn(Optional.of(new TransformXsltEntity()));
+
+    xsltUrlUpdateService.updateXslt("http://document.domain:12345/xlst");
+
+    Mockito.verify(transformXsltRepository, times(1)).save(any());
+  }
+
+  @Test
+  @Order(3)
+  void updateXslt_ExpectFail() {
+    final LogCaptor logCaptor = LogCaptor.forClass(XsltUrlUpdateServiceImpl.class);
+    wm.stubFor(get("/xslt")
+        .withHost(equalTo("document.domain"))
+
+        .withPort(12345)
+        .willReturn(aResponse().withFault(Fault.MALFORMED_RESPONSE_CHUNK)));
+
+    doThrow(RuntimeException.class).when(transformXsltRepository).save(any());
+    xsltUrlUpdateService.updateXslt("http://document.domain:12345/xlst");
+
+    assertLogCaptor(logCaptor, "Error persisting default transform XSLT to Database");
+  }
+
+  @Test
+  @Order(4)
   void updateXslt_ExpectError() {
     final LogCaptor logCaptor = LogCaptor.forClass(XsltUrlUpdateServiceImpl.class);
     xsltUrlUpdateService.updateXslt("");
-    assertLogCaptor(logCaptor);
+    assertLogCaptor(logCaptor, "Error getting default transform XSLT");
   }
 
-  private void assertLogCaptor(LogCaptor logCaptor) {
+  @Test
+  @Order(5)
+  void updateXslt_LoadAsFile_ExpectFail() throws IOException, ReflectiveOperationException, InterruptedException {
+    wm.stubFor(get("/xslt")
+        .withHost(equalTo("document.domain"))
+        .withPort(12345)
+        .willReturn(ok("1")));
+    doThrow(IOException.class).when(httpClient).send(any(HttpRequest.class), any());
+
+    setFinalStaticField(XsltUrlUpdateServiceImpl.class, "httpClient", httpClient);
+
+    xsltUrlUpdateService.updateXslt("http://document.domain:12345/xlst");
+
+    Mockito.verify(transformXsltRepository, never()).save(any());
+  }
+
+  private void assertLogCaptor(LogCaptor logCaptor, String message) {
     assertEquals(1, logCaptor.getWarnLogs().size());
     final String testMessage = logCaptor.getWarnLogs().stream().findFirst().get();
-    assertTrue(testMessage.contains("Error getting default transform XSLT"));
+    assertTrue(testMessage.contains(message));
+  }
+
+  private static void setFinalStaticField(Class<?> clazz, String fieldName, Object value)
+      throws ReflectiveOperationException {
+
+    Field field = clazz.getDeclaredField(fieldName);
+    field.setAccessible(true);
+
+    Field modifiers = Field.class.getDeclaredField("modifiers");
+    modifiers.setAccessible(true);
+    modifiers.setInt(field, field.getModifiers() & ~Modifier.FINAL);
+
+    field.set(null, value);
   }
 }

--- a/src/test/java/eu/europeana/metis/sandbox/service/util/XsltUrlUpdateServiceImplTest.java
+++ b/src/test/java/eu/europeana/metis/sandbox/service/util/XsltUrlUpdateServiceImplTest.java
@@ -1,0 +1,35 @@
+package eu.europeana.metis.sandbox.service.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import eu.europeana.metis.sandbox.repository.TransformXsltRepository;
+import nl.altindag.log.LogCaptor;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class XsltUrlUpdateServiceImplTest {
+
+  @Mock
+  private TransformXsltRepository transformXsltRepository;
+
+  @InjectMocks
+  private XsltUrlUpdateServiceImpl xsltUrlUpdateService;
+
+  @Test
+  void updateXslt_ExpectError() {
+    final LogCaptor logCaptor = LogCaptor.forClass(XsltUrlUpdateServiceImpl.class);
+    xsltUrlUpdateService.updateXslt("");
+    assertLogCaptor(logCaptor);
+  }
+
+  private void assertLogCaptor(LogCaptor logCaptor) {
+    assertEquals(1, logCaptor.getWarnLogs().size());
+    final String testMessage = logCaptor.getWarnLogs().stream().findFirst().get();
+    assertTrue(testMessage.contains("Error getting default transform XSLT"));
+  }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -22,7 +22,23 @@ spring:
   servlet:
     multipart:
       max-file-size: 5MB
-
+  rabbitmq:
+    virtual-host:
+    host: localhost
+    port: 5672
+    ssl:
+      enabled:
+      algorithm:
+    listener:
+      simple:
+        concurrency: 2
+        max-concurrency: 2
+        prefetch: 1
+        retry:
+          enabled: true
+          initial-interval: 1000ms
+          multiplier: 2
+          max-attempts: 3
 sandbox:
   cors:
     mapping: '*'


### PR DESCRIPTION
**Relevant updates:**
- Added unit tests to validate rabbitmq exceptions on executors.
 
- Updated RabbitMQ properties according to the following information.
 spring.rabbitmq.listener.simple.concurrency=2
 spring.rabbitmq.listener.simple.max-concurrency=2 
 
**Parameters based on**:
**Tomcat**: 200 threads max.
**Hikari**: 10 threads x database pool.
**Executor**: 10 threads x publish queue.
**Test machine**: 4 cores, 2 threads per core, 8 threads in parallel. 
**Rabbitmq**: reducing from 10  to 2 concurrent consumers per queue. 22 queues in total. 
Instead of 10x22=220 max concurrent consumers (thinking this is also related with tomcat threads settings, 220>200) to 2x22=44 max concurrent consumers (which is 64 < 200).