### PR TITLE
feat/MET-4284 improve synchronization report in sandbox

### DIFF
--- a/src/main/java/eu/europeana/metis/sandbox/common/Step.java
+++ b/src/main/java/eu/europeana/metis/sandbox/common/Step.java
@@ -7,7 +7,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
  */
 public enum Step {
   HARVEST_OAI_PMH("harvest OAI-PMH",1),
-  HARVEST_ZIP("harvest Zip", 2),
+  HARVEST_ZIP("harvest zip", 2),
   TRANSFORM_TO_EDM_EXTERNAL("transform to EDM external", 3),
   VALIDATE_EXTERNAL("validate (edm external)", 4),
   TRANSFORM("transform", 5),

--- a/src/main/java/eu/europeana/metis/sandbox/dto/report/ErrorInfoDto.java
+++ b/src/main/java/eu/europeana/metis/sandbox/dto/report/ErrorInfoDto.java
@@ -38,4 +38,32 @@ public class ErrorInfoDto {
   public String getErrorMessage() {
     return errorMessage;
   }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof ErrorInfoDto)) {
+      return false;
+    }
+
+    ErrorInfoDto that = (ErrorInfoDto) o;
+
+    if (!errorMessage.equals(that.errorMessage)) {
+      return false;
+    }
+    if (type != that.type) {
+      return false;
+    }
+    return recordIds.equals(that.recordIds);
+  }
+
+  @Override
+  public int hashCode() {
+    int result = errorMessage.hashCode();
+    result = 31 * result + type.hashCode();
+    result = 31 * result + recordIds.hashCode();
+    return result;
+  }
 }

--- a/src/main/java/eu/europeana/metis/sandbox/dto/report/ProgressByStepDto.java
+++ b/src/main/java/eu/europeana/metis/sandbox/dto/report/ProgressByStepDto.java
@@ -6,6 +6,8 @@ import eu.europeana.metis.sandbox.common.Step;
 import io.swagger.annotations.ApiModel;
 import java.util.Collections;
 import java.util.List;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 /**
  * Represent each step progress in the dataset report
@@ -54,5 +56,37 @@ public class ProgressByStepDto {
 
   public List<ErrorInfoDto> getErrors() {
     return errors;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+
+    if (!(o instanceof ProgressByStepDto)) {
+      return false;
+    }
+
+    ProgressByStepDto that = (ProgressByStepDto) o;
+
+    return new EqualsBuilder().append(total, that.total)
+                              .append(success, that.success)
+                              .append(fail, that.fail)
+                              .append(warn, that.warn)
+                              .append(step, that.step)
+                              .append(errors, that.errors).isEquals();
+  }
+
+  @Override
+  public int hashCode() {
+    return new HashCodeBuilder(17, 37)
+        .append(step)
+        .append(total)
+        .append(success)
+        .append(fail)
+        .append(warn)
+        .append(errors)
+        .toHashCode();
   }
 }

--- a/src/main/java/eu/europeana/metis/sandbox/dto/report/ProgressByStepDto.java
+++ b/src/main/java/eu/europeana/metis/sandbox/dto/report/ProgressByStepDto.java
@@ -6,8 +6,6 @@ import eu.europeana.metis.sandbox.common.Step;
 import io.swagger.annotations.ApiModel;
 import java.util.Collections;
 import java.util.List;
-import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 /**
  * Represent each step progress in the dataset report
@@ -63,30 +61,38 @@ public class ProgressByStepDto {
     if (this == o) {
       return true;
     }
-
     if (!(o instanceof ProgressByStepDto)) {
       return false;
     }
 
     ProgressByStepDto that = (ProgressByStepDto) o;
 
-    return new EqualsBuilder().append(total, that.total)
-                              .append(success, that.success)
-                              .append(fail, that.fail)
-                              .append(warn, that.warn)
-                              .append(step, that.step)
-                              .append(errors, that.errors).isEquals();
+    if (total != that.total) {
+      return false;
+    }
+    if (success != that.success) {
+      return false;
+    }
+    if (fail != that.fail) {
+      return false;
+    }
+    if (warn != that.warn) {
+      return false;
+    }
+    if (step != that.step) {
+      return false;
+    }
+    return errors.equals(that.errors);
   }
 
   @Override
   public int hashCode() {
-    return new HashCodeBuilder(17, 37)
-        .append(step)
-        .append(total)
-        .append(success)
-        .append(fail)
-        .append(warn)
-        .append(errors)
-        .toHashCode();
+    int result = step.hashCode();
+    result = 31 * result + (int) (total ^ (total >>> 32));
+    result = 31 * result + (int) (success ^ (success >>> 32));
+    result = 31 * result + (int) (fail ^ (fail >>> 32));
+    result = 31 * result + (int) (warn ^ (warn >>> 32));
+    result = 31 * result + errors.hashCode();
+    return result;
   }
 }

--- a/src/main/java/eu/europeana/metis/sandbox/dto/report/ProgressInfoDto.java
+++ b/src/main/java/eu/europeana/metis/sandbox/dto/report/ProgressInfoDto.java
@@ -51,14 +51,13 @@ public class ProgressInfoDto {
 
   public ProgressInfoDto(String portalPublishUrl, Long totalRecords, Long processedRecords,
       List<ProgressByStepDto> progressByStep, DatasetInfoDto datasetInfoDto) {
-    
     this.processedRecords = processedRecords;
-    if (totalRecords == this.processedRecords) {
-      this.status = Status.COMPLETED;
-      this.totalRecords = totalRecords;
-    } else if (totalRecords == null) {
+    if (totalRecords == null) {
       this.status = Status.HARVESTING_IDENTIFIERS;
       this.totalRecords = 0L;
+    } else if (totalRecords.equals(this.processedRecords)) {
+      this.status = Status.COMPLETED;
+      this.totalRecords = totalRecords;
     } else {
       this.status = Status.IN_PROGRESS;
       this.totalRecords = totalRecords;

--- a/src/main/java/eu/europeana/metis/sandbox/dto/report/ProgressInfoDto.java
+++ b/src/main/java/eu/europeana/metis/sandbox/dto/report/ProgressInfoDto.java
@@ -15,7 +15,7 @@ public class ProgressInfoDto {
 
   public static final String PROGRESS_SWAGGER_MODEL_NAME = "ProgressInfo";
 
-  public enum Status {
+  enum Status {
     HARVESTING_IDENTIFIERS("harvesting identifiers"),
     COMPLETED("completed"),
     IN_PROGRESS("in progress");
@@ -38,10 +38,10 @@ public class ProgressInfoDto {
   private final Status status;
 
   @JsonProperty("total-records")
-  private final int totalRecords;
+  private final Long totalRecords;
 
   @JsonProperty("processed-records")
-  private final long processedRecords;
+  private final Long processedRecords;
 
   @JsonProperty("progress-by-step")
   private final List<ProgressByStepDto> progressByStep;
@@ -49,16 +49,16 @@ public class ProgressInfoDto {
   @JsonProperty("dataset-info")
   private final DatasetInfoDto datasetInfoDto;
 
-  public ProgressInfoDto(String portalPublishUrl, int totalRecords, long processedRecords,
+  public ProgressInfoDto(String portalPublishUrl, Long totalRecords, Long processedRecords,
       List<ProgressByStepDto> progressByStep, DatasetInfoDto datasetInfoDto) {
     
     this.processedRecords = processedRecords;
     if (totalRecords == this.processedRecords) {
       this.status = Status.COMPLETED;
       this.totalRecords = totalRecords;
-    } else if (totalRecords == -1) {
+    } else if (totalRecords == null) {
       this.status = Status.HARVESTING_IDENTIFIERS;
-      this.totalRecords = 0;
+      this.totalRecords = 0L;
     } else {
       this.status = Status.IN_PROGRESS;
       this.totalRecords = totalRecords;

--- a/src/main/java/eu/europeana/metis/sandbox/dto/report/ProgressInfoDto.java
+++ b/src/main/java/eu/europeana/metis/sandbox/dto/report/ProgressInfoDto.java
@@ -15,7 +15,8 @@ public class ProgressInfoDto {
 
   public static final String PROGRESS_SWAGGER_MODEL_NAME = "ProgressInfo";
 
-  private enum Status {
+  public enum Status {
+    HARVESTING_IDENTIFIERS("harvesting identifiers"),
     COMPLETED("completed"),
     IN_PROGRESS("in progress");
 
@@ -37,7 +38,7 @@ public class ProgressInfoDto {
   private final Status status;
 
   @JsonProperty("total-records")
-  private final long totalRecords;
+  private final int totalRecords;
 
   @JsonProperty("processed-records")
   private final long processedRecords;
@@ -48,13 +49,20 @@ public class ProgressInfoDto {
   @JsonProperty("dataset-info")
   private final DatasetInfoDto datasetInfoDto;
 
-  public ProgressInfoDto(String portalPublishUrl,
-      int totalRecords,
-      long processedRecords, List<ProgressByStepDto> progressByStep, DatasetInfoDto datasetInfoDto) {
-    this.totalRecords = totalRecords;
+  public ProgressInfoDto(String portalPublishUrl, int totalRecords, long processedRecords,
+      List<ProgressByStepDto> progressByStep, DatasetInfoDto datasetInfoDto) {
+    
     this.processedRecords = processedRecords;
-    this.status =
-        this.totalRecords == this.processedRecords ? Status.COMPLETED : Status.IN_PROGRESS;
+    if (totalRecords == this.processedRecords) {
+      this.status = Status.COMPLETED;
+      this.totalRecords = totalRecords;
+    } else if (totalRecords == -1) {
+      this.status = Status.HARVESTING_IDENTIFIERS;
+      this.totalRecords = 0;
+    } else {
+      this.status = Status.IN_PROGRESS;
+      this.totalRecords = totalRecords;
+    }
     this.progressByStep = Collections.unmodifiableList(progressByStep);
     this.portalPublishUrl = portalPublishUrl;
     this.datasetInfoDto = datasetInfoDto;

--- a/src/main/java/eu/europeana/metis/sandbox/entity/DatasetEntity.java
+++ b/src/main/java/eu/europeana/metis/sandbox/entity/DatasetEntity.java
@@ -25,7 +25,7 @@ public class DatasetEntity {
 
   private String datasetName;
 
-  private Integer recordsQuantity;
+  private Long recordsQuantity;
 
   @Column(insertable = false, updatable = false)
   private LocalDateTime createdDate;
@@ -40,7 +40,7 @@ public class DatasetEntity {
 
   private Boolean recordLimitExceeded;
 
-  public DatasetEntity(String datasetName, Integer recordsQuantity, Language language, Country country,
+  public DatasetEntity(String datasetName, Long recordsQuantity, Language language, Country country,
       Boolean recordLimitExceeded) {
     this.datasetName = datasetName;
     this.recordsQuantity = recordsQuantity;
@@ -50,7 +50,7 @@ public class DatasetEntity {
 
   }
 
-  public DatasetEntity(String datasetName, Integer recordsQuantity, Language language, Country country,
+  public DatasetEntity(String datasetName, Long recordsQuantity, Language language, Country country,
       Boolean recordLimitExceeded, String xsltEdmExternalContent) {
     this(datasetName, recordsQuantity, language, country, recordLimitExceeded);
     this.xsltEdmExternalContent = xsltEdmExternalContent;
@@ -76,11 +76,11 @@ public class DatasetEntity {
     this.datasetName = datasetName;
   }
 
-  public Integer getRecordsQuantity() {
+  public Long getRecordsQuantity() {
     return recordsQuantity;
   }
 
-  public void setRecordsQuantity(Integer recordsQuantity) {
+  public void setRecordsQuantity(Long recordsQuantity) {
     this.recordsQuantity = recordsQuantity;
   }
 

--- a/src/main/java/eu/europeana/metis/sandbox/entity/StepStatistic.java
+++ b/src/main/java/eu/europeana/metis/sandbox/entity/StepStatistic.java
@@ -13,9 +13,9 @@ public class StepStatistic {
 
   private final Status status;
 
-  private final long count;
+  private final Long count;
 
-  public StepStatistic(Step step, Status status, long count) {
+  public StepStatistic(Step step, Status status, Long count) {
     this.step = step;
     this.status = status;
     this.count = count;
@@ -29,7 +29,7 @@ public class StepStatistic {
     return status;
   }
 
-  public long getCount() {
+  public Long getCount() {
     return count;
   }
 }

--- a/src/main/java/eu/europeana/metis/sandbox/repository/DatasetRepository.java
+++ b/src/main/java/eu/europeana/metis/sandbox/repository/DatasetRepository.java
@@ -28,7 +28,7 @@ public interface DatasetRepository extends JpaRepository<DatasetEntity, Integer>
    */
   @Modifying
   @Query("UPDATE DatasetEntity dataset SET dataset.recordsQuantity = ?2 WHERE dataset.datasetId = ?1")
-  void updateRecordsQuantity(int datasetId, int quantity);
+  void updateRecordsQuantity(int datasetId, Long quantity);
 
   /**
    * Sets to true the boolean recordLimitExceeded

--- a/src/main/java/eu/europeana/metis/sandbox/service/dataset/DatasetReportServiceImpl.java
+++ b/src/main/java/eu/europeana/metis/sandbox/service/dataset/DatasetReportServiceImpl.java
@@ -38,9 +38,10 @@ import org.springframework.transaction.annotation.Transactional;
 class DatasetReportServiceImpl implements DatasetReportService {
 
   private static final int FIRST = 0;
-  private static final String EMPTY_DATASET = "Dataset is empty";
-  private static final String PROCESSING_MSG = "A review URL will be generated when the dataset has finished processing";
-  private static final String FINISH_ALL_ERRORS = "All dataset records failed to be processed";
+  private static final String EMPTY_DATASET = "Dataset is empty.";
+  private static final String HARVESTING = "Harvesting dataset identifiers and records.";
+  private static final String PROCESSING_MSG = "A review URL will be generated when the dataset has finished processing.";
+  private static final String FINISH_ALL_ERRORS = "All dataset records failed to be processed.";
   private static final String SEPARATOR = "_";
   private static final String SUFFIX = "*";
 
@@ -122,6 +123,9 @@ class DatasetReportServiceImpl implements DatasetReportService {
   private String getPortalUrl(String portal, DatasetEntity dataset, long completedRecords,
       long failedRecords) {
     long recordsQty = dataset.getRecordsQuantity();
+    if (recordsQty == -1) {
+      return HARVESTING;
+    }
     if (recordsQty == 0) {
       return EMPTY_DATASET;
     }

--- a/src/main/java/eu/europeana/metis/sandbox/service/dataset/DatasetReportServiceImpl.java
+++ b/src/main/java/eu/europeana/metis/sandbox/service/dataset/DatasetReportServiceImpl.java
@@ -115,24 +115,24 @@ class DatasetReportServiceImpl implements DatasetReportService {
         stepsInfo, datasetInfoDto);
   }
 
-  private String getPublishPortalUrl(DatasetEntity dataset, long completedRecords,
-      long failedRecords) {
+  private String getPublishPortalUrl(DatasetEntity dataset, Long completedRecords,
+      Long failedRecords) {
     return getPortalUrl(portalPublishDatasetUrl, dataset, completedRecords, failedRecords);
   }
 
-  private String getPortalUrl(String portal, DatasetEntity dataset, long completedRecords,
-      long failedRecords) {
-    long recordsQty = dataset.getRecordsQuantity();
-    if (recordsQty == -1) {
+  private String getPortalUrl(String portal, DatasetEntity dataset, Long completedRecords,
+      Long failedRecords) {
+    Long recordsQty = dataset.getRecordsQuantity();
+    if (recordsQty == null) {
       return HARVESTING_IDENTIFIERS_MESSAGE;
     }
     if (recordsQty == 0) {
       return EMPTY_DATASET_MESSAGE;
     }
-    if (recordsQty != completedRecords) {
+    if (!recordsQty.equals(completedRecords)) {
       return PROCESSING_DATASET_MESSAGE;
     }
-    if (completedRecords == failedRecords) {
+    if (completedRecords.equals(failedRecords)) {
       return FINISH_ALL_ERRORS_MESSAGE;
     }
     var datasetId = dataset.getDatasetId() + SEPARATOR + dataset.getDatasetName() + SUFFIX;
@@ -152,7 +152,7 @@ class DatasetReportServiceImpl implements DatasetReportService {
     return optionalDataset.orElseThrow(() -> new InvalidDatasetException(datasetId));
   }
 
-  private long getCompletedRecords(List<StepStatistic> stepStatistics) {
+  private Long getCompletedRecords(List<StepStatistic> stepStatistics) {
     return stepStatistics.stream()
         .filter(current -> current.getStep() == Step.CLOSE || current.getStatus() == Status.FAIL)
         .mapToLong(StepStatistic::getCount)

--- a/src/main/java/eu/europeana/metis/sandbox/service/dataset/DatasetReportServiceImpl.java
+++ b/src/main/java/eu/europeana/metis/sandbox/service/dataset/DatasetReportServiceImpl.java
@@ -38,10 +38,10 @@ import org.springframework.transaction.annotation.Transactional;
 class DatasetReportServiceImpl implements DatasetReportService {
 
   private static final int FIRST = 0;
-  private static final String EMPTY_DATASET = "Dataset is empty.";
-  private static final String HARVESTING = "Harvesting dataset identifiers and records.";
-  private static final String PROCESSING_MSG = "A review URL will be generated when the dataset has finished processing.";
-  private static final String FINISH_ALL_ERRORS = "All dataset records failed to be processed.";
+  private static final String EMPTY_DATASET_MESSAGE = "Dataset is empty.";
+  private static final String HARVESTING_IDENTIFIERS_MESSAGE = "Harvesting dataset identifiers and records.";
+  private static final String PROCESSING_DATASET_MESSAGE = "A review URL will be generated when the dataset has finished processing.";
+  private static final String FINISH_ALL_ERRORS_MESSAGE = "All dataset records failed to be processed.";
   private static final String SEPARATOR = "_";
   private static final String SUFFIX = "*";
 
@@ -124,16 +124,16 @@ class DatasetReportServiceImpl implements DatasetReportService {
       long failedRecords) {
     long recordsQty = dataset.getRecordsQuantity();
     if (recordsQty == -1) {
-      return HARVESTING;
+      return HARVESTING_IDENTIFIERS_MESSAGE;
     }
     if (recordsQty == 0) {
-      return EMPTY_DATASET;
+      return EMPTY_DATASET_MESSAGE;
     }
     if (recordsQty != completedRecords) {
-      return PROCESSING_MSG;
+      return PROCESSING_DATASET_MESSAGE;
     }
     if (completedRecords == failedRecords) {
-      return FINISH_ALL_ERRORS;
+      return FINISH_ALL_ERRORS_MESSAGE;
     }
     var datasetId = dataset.getDatasetId() + SEPARATOR + dataset.getDatasetName() + SUFFIX;
     return portal + URLEncoder.encode(datasetId, StandardCharsets.UTF_8);

--- a/src/main/java/eu/europeana/metis/sandbox/service/dataset/DatasetService.java
+++ b/src/main/java/eu/europeana/metis/sandbox/service/dataset/DatasetService.java
@@ -50,7 +50,7 @@ public interface DatasetService {
    * @param datasetId The id of the dataset to update to
    * @param numberOfRecords The new value to update into the dataset
    */
-  void updateNumberOfTotalRecord(String datasetId, int numberOfRecords);
+  void updateNumberOfTotalRecord(String datasetId, Long numberOfRecords);
 
   /**
    * Sets to true the boolean recordLimitExceeded in the database

--- a/src/main/java/eu/europeana/metis/sandbox/service/dataset/DatasetServiceImpl.java
+++ b/src/main/java/eu/europeana/metis/sandbox/service/dataset/DatasetServiceImpl.java
@@ -74,7 +74,7 @@ class DatasetServiceImpl implements DatasetService {
 
   @Override
   @Transactional
-  public void updateNumberOfTotalRecord(String datasetId, int numberOfRecords) {
+  public void updateNumberOfTotalRecord(String datasetId, Long numberOfRecords) {
     datasetRepository.updateRecordsQuantity(Integer.parseInt(datasetId), numberOfRecords);
   }
 

--- a/src/main/java/eu/europeana/metis/sandbox/service/dataset/DatasetServiceImpl.java
+++ b/src/main/java/eu/europeana/metis/sandbox/service/dataset/DatasetServiceImpl.java
@@ -39,7 +39,7 @@ class DatasetServiceImpl implements DatasetService {
     requireNonNull(country, "Country must not be null");
     requireNonNull(language, "Language must not be null");
 
-    DatasetEntity entity = saveNewDatasetInDatabase(new DatasetEntity(datasetName, 0, language, country, false),
+    DatasetEntity entity = saveNewDatasetInDatabase(new DatasetEntity(datasetName, 0L, language, country, false),
             xsltEdmExternalContentStream);
 
     return String.valueOf(entity.getDatasetId());

--- a/src/main/java/eu/europeana/metis/sandbox/service/workflow/HarvestPublishServiceImpl.java
+++ b/src/main/java/eu/europeana/metis/sandbox/service/workflow/HarvestPublishServiceImpl.java
@@ -73,6 +73,5 @@ public class HarvestPublishServiceImpl implements HarvestPublishService {
         Record.RecordBuilder recordDataEncapsulated = Record.builder().country(country).language(language).datasetName(datasetName).datasetId(datasetId);
         return CompletableFuture.runAsync(
                 () -> harvestService.harvestOaiPmh(datasetId, recordDataEncapsulated, oaiHarvestData), asyncServiceTaskExecutor);
-
     }
 }

--- a/src/main/java/eu/europeana/metis/sandbox/service/workflow/HarvestServiceImpl.java
+++ b/src/main/java/eu/europeana/metis/sandbox/service/workflow/HarvestServiceImpl.java
@@ -28,7 +28,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
@@ -77,14 +77,14 @@ public class HarvestServiceImpl implements HarvestService {
   private List<RecordInfo> harvestOaiIdentifiers(String datasetId, Record.RecordBuilder recordDataEncapsulated,
       OaiHarvestData oaiHarvestData) {
     List<RecordInfo> recordInfoList = new ArrayList<>();
-    datasetService.updateNumberOfTotalRecord(datasetId, -1);
+    datasetService.updateNumberOfTotalRecord(datasetId, null);
 
     try (OaiRecordHeaderIterator recordHeaderIterator = oaiHarvester.harvestRecordHeaders(
         new OaiHarvest(oaiHarvestData.getUrl(),
             oaiHarvestData.getMetadataformat(),
             oaiHarvestData.getSetspec()))) {
 
-      AtomicInteger currentNumberOfIterations = new AtomicInteger();
+      AtomicLong currentNumberOfIterations = new AtomicLong();
 
       recordHeaderIterator.forEach(recordHeader -> {
         OaiHarvestData completeOaiHarvestData = new OaiHarvestData(oaiHarvestData.getUrl(),
@@ -104,7 +104,7 @@ public class HarvestServiceImpl implements HarvestService {
           return ReportingIteration.IterationResult.TERMINATE;
         }
 
-        recordInfoList.add(harvestOaiRecordHeader(datasetId, completeOaiHarvestData,
+        recordInfoList.add(harvestOaiRecords(datasetId, completeOaiHarvestData,
             recordDataEncapsulated));
 
         return ReportingIteration.IterationResult.CONTINUE;
@@ -118,7 +118,7 @@ public class HarvestServiceImpl implements HarvestService {
     return recordInfoList;
   }
 
-  private RecordInfo harvestOaiRecordHeader(String datasetId, OaiHarvestData oaiHarvestData,
+  private RecordInfo harvestOaiRecords(String datasetId, OaiHarvestData oaiHarvestData,
       Record.RecordBuilder recordToHarvest) {
 
     List<RecordError> recordErrors = new ArrayList<>();
@@ -159,10 +159,10 @@ public class HarvestServiceImpl implements HarvestService {
       Record.RecordBuilder recordDataEncapsulated) {
     List<Pair<Path, Exception>> exception = new ArrayList<>(1);
     List<RecordInfo> recordInfoList = new ArrayList<>();
-    datasetService.updateNumberOfTotalRecord(datasetId, -1);
+    datasetService.updateNumberOfTotalRecord(datasetId, null);
 
     try {
-      AtomicInteger numberOfIterations = new AtomicInteger(0);
+      AtomicLong numberOfIterations = new AtomicLong(0);
       final HttpRecordIterator iterator = httpHarvester.createTemporaryHttpHarvestIterator(inputStream,
           CompressedFileExtension.ZIP);
       iterator.forEach(path -> {

--- a/src/main/resources/database/schema.sql
+++ b/src/main/resources/database/schema.sql
@@ -15,7 +15,7 @@ begin;
 create table if not exists dataset (
    dataset_id serial,
    dataset_name varchar(255) not null,
-   records_quantity integer not null,
+   records_quantity integer null,
    created_date timestamp with time zone default now(),
    country varchar(35) not null,
    language varchar(3) not null,

--- a/src/test/java/eu/europeana/metis/sandbox/common/StepTest.java
+++ b/src/test/java/eu/europeana/metis/sandbox/common/StepTest.java
@@ -1,0 +1,38 @@
+package eu.europeana.metis.sandbox.common;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * Unit test for {@link Step}
+ */
+class StepTest {
+
+  private static Stream<Arguments> provideExpectedStepsAndValues() {
+    return Stream.of(
+        Arguments.of(Step.HARVEST_OAI_PMH, "harvest OAI-PMH", 1),
+        Arguments.of(Step.HARVEST_ZIP, "harvest zip", 2),
+        Arguments.of(Step.TRANSFORM_TO_EDM_EXTERNAL, "transform to EDM external", 3),
+        Arguments.of(Step.VALIDATE_EXTERNAL, "validate (edm external)", 4),
+        Arguments.of(Step.TRANSFORM, "transform", 5),
+        Arguments.of(Step.VALIDATE_INTERNAL, "validate (edm internal)", 6),
+        Arguments.of(Step.NORMALIZE, "normalise", 7),
+        Arguments.of(Step.ENRICH, "enrich", 8),
+        Arguments.of(Step.MEDIA_PROCESS, "process media", 9),
+        Arguments.of(Step.PUBLISH, "publish", 10),
+        Arguments.of(Step.CLOSE, "close", 11)
+    );
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideExpectedStepsAndValues")
+  void valueOf(Step expectedStep, String value, Integer precedence) {
+    assertEquals(expectedStep.value(), value);
+    assertEquals(expectedStep.precedence(), precedence);
+  }
+}

--- a/src/test/java/eu/europeana/metis/sandbox/controller/DatasetControllerTest.java
+++ b/src/test/java/eu/europeana/metis/sandbox/controller/DatasetControllerTest.java
@@ -316,7 +316,7 @@ class DatasetControllerTest {
         var datasetInfoDto = new DatasetInfoDto("12345", "Test", LocalDateTime.MIN, Language.NL,
                 Country.NETHERLANDS, false, false);
         var report = new ProgressInfoDto("https://metis-sandbox",
-                10, 10L, List.of(createProgress, externalProgress), datasetInfoDto);
+                10L, 10L, List.of(createProgress, externalProgress), datasetInfoDto);
         when(datasetReportService.getReport("1")).thenReturn(report);
 
         mvc.perform(get("/dataset/{id}", "1"))

--- a/src/test/java/eu/europeana/metis/sandbox/dto/report/ErrorInfoDtoTest.java
+++ b/src/test/java/eu/europeana/metis/sandbox/dto/report/ErrorInfoDtoTest.java
@@ -1,0 +1,61 @@
+package eu.europeana.metis.sandbox.dto.report;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import eu.europeana.metis.sandbox.common.Status;
+import java.util.List;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit test for {@link ErrorInfoDto}
+ */
+class ErrorInfoDtoTest {
+
+  @Test
+  void getRecordIds() {
+    ErrorInfoDto errorInfoDto = getTestErrorInfoDto();
+
+    assertEquals(List.of("1", "2", "3", "4", "5"), errorInfoDto.getRecordIds());
+  }
+
+  @Test
+  void getType() {
+    ErrorInfoDto errorInfoDto = getTestErrorInfoDto();
+
+    assertEquals(Status.WARN, errorInfoDto.getType());
+  }
+
+  @Test
+  void getErrorMessage() {
+    ErrorInfoDto errorInfoDto = getTestErrorInfoDto();
+
+    assertEquals("warn message", errorInfoDto.getErrorMessage());
+  }
+
+  @Test
+  void testEquals() {
+    ErrorInfoDto errorInfoDto1 = getTestErrorInfoDto();
+    ErrorInfoDto errorInfoDto2 = getTestErrorInfoDto();
+
+    assertTrue(errorInfoDto1.equals(errorInfoDto2) && errorInfoDto2.equals(errorInfoDto1));
+    assertFalse(errorInfoDto1.equals(null) && errorInfoDto2.equals(null));
+  }
+
+  @Test
+  void testHashCode() {
+    ErrorInfoDto errorInfoDto1 = getTestErrorInfoDto();
+    ErrorInfoDto errorInfoDto2 = getTestErrorInfoDto();
+
+    assertEquals(errorInfoDto1.hashCode(), errorInfoDto2.hashCode());
+  }
+
+  @NotNull
+  private static ErrorInfoDto getTestErrorInfoDto() {
+    return new ErrorInfoDto("warn message",
+        Status.WARN,
+        List.of("1", "2", "3", "4", "5"));
+  }
+}

--- a/src/test/java/eu/europeana/metis/sandbox/dto/report/ProgressByStepDtoTest.java
+++ b/src/test/java/eu/europeana/metis/sandbox/dto/report/ProgressByStepDtoTest.java
@@ -1,0 +1,89 @@
+package eu.europeana.metis.sandbox.dto.report;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import eu.europeana.metis.sandbox.common.Status;
+import eu.europeana.metis.sandbox.common.Step;
+import java.util.List;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit test for {@link ProgressByStepDto}
+ */
+class ProgressByStepDtoTest {
+
+  @Test
+  void getStep() {
+    ProgressByStepDto progressByStepDto = getTestProgressByStepDto();
+
+    assertEquals(Step.TRANSFORM, progressByStepDto.getStep());
+  }
+
+  @Test
+  void getTotal() {
+    ProgressByStepDto progressByStepDto = getTestProgressByStepDto();
+
+    assertEquals(19L, progressByStepDto.getTotal());
+  }
+
+  @Test
+  void getSuccess() {
+    ProgressByStepDto progressByStepDto = getTestProgressByStepDto();
+
+    assertEquals(12L, progressByStepDto.getSuccess());
+  }
+
+  @Test
+  void getFail() {
+    ProgressByStepDto progressByStepDto = getTestProgressByStepDto();
+
+    assertEquals(5L, progressByStepDto.getFail());
+  }
+
+  @Test
+  void getWarn() {
+    ProgressByStepDto progressByStepDto = getTestProgressByStepDto();
+
+    assertEquals(2L, progressByStepDto.getWarn());
+  }
+
+  @Test
+  void getErrors() {
+    ProgressByStepDto progressByStepDto = getTestProgressByStepDto();
+
+    assertEquals(List.of(new ErrorInfoDto("fail message", Status.FAIL, List.of("1", "2", "3", "4", "5")),
+        new ErrorInfoDto("warn message", Status.WARN, List.of("6", "7"))), progressByStepDto.getErrors());
+  }
+
+  @Test
+  void testEquals() {
+    ProgressByStepDto progressByStepDto1 = getTestProgressByStepDto();
+    ProgressByStepDto progressByStepDto2 = getTestProgressByStepDto();
+
+    assertTrue(progressByStepDto1.equals(progressByStepDto2) && progressByStepDto2.equals(progressByStepDto1));
+    assertFalse( progressByStepDto1.equals(null) && progressByStepDto2.equals(null));
+  }
+
+  @Test
+  void testHashCode() {
+    ProgressByStepDto progressByStepDto1 = getTestProgressByStepDto();
+    ProgressByStepDto progressByStepDto2 = getTestProgressByStepDto();
+
+    assertEquals(progressByStepDto2.hashCode(), progressByStepDto1.hashCode());
+  }
+
+  @NotNull
+  private static ProgressByStepDto getTestProgressByStepDto() {
+    return new ProgressByStepDto(Step.TRANSFORM,
+        12,
+        5,
+        2,
+        List.of(new ErrorInfoDto("fail message",
+                Status.FAIL, List.of("1", "2", "3", "4", "5")),
+            new ErrorInfoDto("warn message",
+                Status.WARN, List.of("6", "7"))));
+  }
+}

--- a/src/test/java/eu/europeana/metis/sandbox/dto/report/ProgressInfoDtoTest.java
+++ b/src/test/java/eu/europeana/metis/sandbox/dto/report/ProgressInfoDtoTest.java
@@ -1,0 +1,138 @@
+package eu.europeana.metis.sandbox.dto.report;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import eu.europeana.metis.sandbox.common.Step;
+import eu.europeana.metis.sandbox.common.locale.Country;
+import eu.europeana.metis.sandbox.common.locale.Language;
+import eu.europeana.metis.sandbox.dto.DatasetInfoDto;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Stream;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * Unit test for {@link ProgressInfoDto}
+ */
+class ProgressInfoDtoTest {
+
+  private ProgressInfoDto progressInfoDto;
+
+  @Test
+  void getPortalPublishUrl() {
+    progressInfoDto = getTestProgressInfoDto();
+    assertEquals("http://metis-sandbox", progressInfoDto.getPortalPublishUrl());
+  }
+
+  private static Stream<Arguments> provideStatus() {
+    return Stream.of(
+        Arguments.of(getTestHarvestingIdsInfoDto(), ProgressInfoDto.Status.HARVESTING_IDENTIFIERS),
+        Arguments.of(getTestProgressInfoDto(), ProgressInfoDto.Status.IN_PROGRESS),
+        Arguments.of(getTestCompletedInfoDto(), ProgressInfoDto.Status.COMPLETED)
+    );
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideStatus")
+  void getStatus(ProgressInfoDto progressInfoDto, ProgressInfoDto.Status expectedStatus) {
+    assertEquals(expectedStatus, progressInfoDto.getStatus());
+  }
+
+  private static Stream<Arguments> provideProcessed() {
+    return Stream.of(
+        Arguments.of(getTestHarvestingIdsInfoDto(), 0L),
+        Arguments.of(getTestProgressInfoDto(), 2L),
+        Arguments.of(getTestCompletedInfoDto(), 5L)
+    );
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideProcessed")
+  void getProcessedRecords(ProgressInfoDto progressInfoDto, Long expectedProcessed) {
+    assertEquals(expectedProcessed, progressInfoDto.getProcessedRecords());
+  }
+
+  @Test
+  void getProgressByStep() {
+    progressInfoDto = getTestProgressInfoDto();
+    final List<ProgressByStepDto> expectedProgressByStepDtoList = getProgressByStepDtoList(2, 1);
+    assertTrue(progressInfoDto.getProgressByStep().stream()
+                              .allMatch(progressByStepDto -> expectedProgressByStepDtoList.contains(progressByStepDto)));
+  }
+
+  @Test
+  void getDatasetInfoDto() {
+    progressInfoDto = getTestProgressInfoDto();
+
+    assertEquals("datasetId", progressInfoDto.getDatasetInfoDto().getDatasetId());
+    assertEquals("datasetName", progressInfoDto.getDatasetInfoDto().getDatasetName());
+    assertEquals(LocalDateTime.parse("2022-03-14T22:50:22"), progressInfoDto.getDatasetInfoDto().getCreationDate());
+    assertEquals(Country.CROATIA, progressInfoDto.getDatasetInfoDto().getCountry());
+    assertEquals(Language.HR, progressInfoDto.getDatasetInfoDto().getLanguage());
+    assertEquals(false, progressInfoDto.getDatasetInfoDto().isRecordLimitExceeded());
+    assertEquals(false, progressInfoDto.getDatasetInfoDto().isTransformedToEdmExternal());
+  }
+
+  @NotNull
+  private static ProgressInfoDto getTestProgressInfoDto() {
+    return new ProgressInfoDto("http://metis-sandbox",
+        5,
+        2L,
+        getProgressByStepDtoList(2, 1),
+        new DatasetInfoDto("datasetId",
+            "datasetName",
+            LocalDateTime.parse("2022-03-14T22:50:22"),
+            Language.HR,
+            Country.CROATIA,
+            false,
+            false));
+  }
+
+  @NotNull
+  private static List<ProgressByStepDto> getProgressByStepDtoList(int success, int success1) {
+    return List.of(new ProgressByStepDto(Step.HARVEST_ZIP, 5, 0, 0, List.of()),
+        new ProgressByStepDto(Step.TRANSFORM_TO_EDM_EXTERNAL, 5, 0, 0, List.of()),
+        new ProgressByStepDto(Step.VALIDATE_EXTERNAL, 5, 0, 0, List.of()),
+        new ProgressByStepDto(Step.TRANSFORM, 5, 0, 0, List.of()),
+        new ProgressByStepDto(Step.VALIDATE_INTERNAL, 5, 0, 0, List.of()),
+        new ProgressByStepDto(Step.NORMALIZE, 5, 0, 0, List.of()),
+        new ProgressByStepDto(Step.ENRICH, 5, 0, 0, List.of()),
+        new ProgressByStepDto(Step.MEDIA_PROCESS, success, 0, 0, List.of()),
+        new ProgressByStepDto(Step.PUBLISH, success1, 0, 0, List.of()));
+  }
+
+  @NotNull
+  private static ProgressInfoDto getTestHarvestingIdsInfoDto() {
+    return new ProgressInfoDto("http://metis-sandbox",
+        -1,
+        0L,
+        List.of(new ProgressByStepDto(Step.HARVEST_ZIP, 0, 0, 0, List.of())),
+        new DatasetInfoDto("datasetId",
+            "datasetName",
+            LocalDateTime.parse("2022-03-14T22:50:22"),
+            Language.HR,
+            Country.CROATIA,
+            false,
+            false));
+  }
+
+  @NotNull
+  private static ProgressInfoDto getTestCompletedInfoDto() {
+    return new ProgressInfoDto("http://metis-sandbox",
+        5,
+        5L,
+        getProgressByStepDtoList(5, 5),
+        new DatasetInfoDto("datasetId",
+            "datasetName",
+            LocalDateTime.parse("2022-03-14T22:50:22"),
+            Language.HR,
+            Country.CROATIA,
+            false,
+            false));
+  }
+}

--- a/src/test/java/eu/europeana/metis/sandbox/dto/report/ProgressInfoDtoTest.java
+++ b/src/test/java/eu/europeana/metis/sandbox/dto/report/ProgressInfoDtoTest.java
@@ -81,7 +81,7 @@ class ProgressInfoDtoTest {
   @NotNull
   private static ProgressInfoDto getTestProgressInfoDto() {
     return new ProgressInfoDto("http://metis-sandbox",
-        5,
+        5L,
         2L,
         getProgressByStepDtoList(2, 1),
         new DatasetInfoDto("datasetId",
@@ -109,7 +109,7 @@ class ProgressInfoDtoTest {
   @NotNull
   private static ProgressInfoDto getTestHarvestingIdsInfoDto() {
     return new ProgressInfoDto("http://metis-sandbox",
-        -1,
+        null,
         0L,
         List.of(new ProgressByStepDto(Step.HARVEST_ZIP, 0, 0, 0, List.of())),
         new DatasetInfoDto("datasetId",
@@ -124,7 +124,7 @@ class ProgressInfoDtoTest {
   @NotNull
   private static ProgressInfoDto getTestCompletedInfoDto() {
     return new ProgressInfoDto("http://metis-sandbox",
-        5,
+        5L,
         5L,
         getProgressByStepDtoList(5, 5),
         new DatasetInfoDto("datasetId",

--- a/src/test/java/eu/europeana/metis/sandbox/service/dataset/DatasetReportServiceImplTest.java
+++ b/src/test/java/eu/europeana/metis/sandbox/service/dataset/DatasetReportServiceImplTest.java
@@ -57,7 +57,7 @@ class DatasetReportServiceImplTest {
 
     @Test
     void getReportWithErrors_expectSuccess() {
-        var dataset = new DatasetEntity("dataset", 5, Language.NL, Country.NETHERLANDS, false);
+        var dataset = new DatasetEntity("dataset", 5L, Language.NL, Country.NETHERLANDS, false);
         var message1 = "cvc-complex-type.4: Attribute 'resource' must appear on element 'edm:object'.";
         var message2 = "cvc-complex-type.2.4.b: The content of element 'edm:ProvidedCHO' is not complete.";
         var error1 = new ErrorInfoDto(message1, Status.FAIL, List.of("1 | providerId1 | europeanaId1", "2 | providerId2 | europeanaId2"));
@@ -67,14 +67,14 @@ class DatasetReportServiceImplTest {
         var externalProgress = new ProgressByStepDto(Step.VALIDATE_EXTERNAL, 1, 4, 0, errors);
         var report = new ProgressInfoDto(
                 "A review URL will be generated when the dataset has finished processing.",
-                5, 4L,
+                5L, 4L,
                 List.of(createProgress, externalProgress),
                 new DatasetInfoDto("", "", LocalDateTime.now(), Language.NL, Country.NETHERLANDS,
                         false, false));
 
-        var recordViewCreate = new StepStatistic(Step.HARVEST_ZIP, Status.SUCCESS, 5);
-        var recordViewExternal1 = new StepStatistic(Step.VALIDATE_EXTERNAL, Status.SUCCESS, 1);
-        var recordViewExternal2 = new StepStatistic(Step.VALIDATE_EXTERNAL, Status.FAIL, 4);
+        var recordViewCreate = new StepStatistic(Step.HARVEST_ZIP, Status.SUCCESS, 5L);
+        var recordViewExternal1 = new StepStatistic(Step.VALIDATE_EXTERNAL, Status.SUCCESS, 1L);
+        var recordViewExternal2 = new StepStatistic(Step.VALIDATE_EXTERNAL, Status.FAIL, 4L);
         var errorView1 = new ErrorLogViewImpl(1L, getTestRecordEntity(1L), Step.VALIDATE_EXTERNAL, Status.FAIL,
                 "cvc-complex-type.4: Attribute 'resource' must appear on element 'edm:object'.");
         var errorView2 = new ErrorLogViewImpl(1L, getTestRecordEntity(2L), Step.VALIDATE_EXTERNAL, Status.FAIL,
@@ -97,17 +97,17 @@ class DatasetReportServiceImplTest {
 
     @Test
     void getReportWithoutErrors_expectSuccess() {
-        var dataset = new DatasetEntity("dataset", 5, Language.NL, Country.NETHERLANDS, false);
+        var dataset = new DatasetEntity("dataset", 5L, Language.NL, Country.NETHERLANDS, false);
         var createProgress = new ProgressByStepDto(Step.HARVEST_ZIP, 5, 0, 0, List.of());
         var externalProgress = new ProgressByStepDto(Step.VALIDATE_EXTERNAL, 5, 0, 0, List.of());
         var report = new ProgressInfoDto(
                 "A review URL will be generated when the dataset has finished processing.",
-                5, 0L,
+                5L, 0L,
                 List.of(createProgress, externalProgress),
                 new DatasetInfoDto("", "", LocalDateTime.now(), null, null, false, false));
 
-        var recordViewCreate = new StepStatistic(Step.HARVEST_ZIP, Status.SUCCESS, 5);
-        var recordViewExternal = new StepStatistic(Step.VALIDATE_EXTERNAL, Status.SUCCESS, 5);
+        var recordViewCreate = new StepStatistic(Step.HARVEST_ZIP, Status.SUCCESS, 5L);
+        var recordViewExternal = new StepStatistic(Step.VALIDATE_EXTERNAL, Status.SUCCESS, 5L);
 
         when(datasetRepository.findById(1)).thenReturn(Optional.of(dataset));
         when(recordLogRepository.getStepStatistics("1")).thenReturn(
@@ -122,19 +122,19 @@ class DatasetReportServiceImplTest {
 
     @Test
     void getReportCompleted_expectSuccess() {
-        var dataset = new DatasetEntity("dataset", 5, Language.NL, Country.NETHERLANDS, false);
+        var dataset = new DatasetEntity("dataset", 5L, Language.NL, Country.NETHERLANDS, false);
         var createProgress = new ProgressByStepDto(Step.HARVEST_ZIP, 5, 0, 0, List.of());
         var externalProgress = new ProgressByStepDto(Step.VALIDATE_EXTERNAL, 5, 0, 0, List.of());
 
         var report = new ProgressInfoDto(
-                "https://metis-sandbox/portal/publish/search?q=edm_datasetName:null_dataset*", 5, 5L,
+                "https://metis-sandbox/portal/publish/search?q=edm_datasetName:null_dataset*", 5L, 5L,
                 List.of(createProgress, externalProgress),
                 new DatasetInfoDto("", "", LocalDateTime.now(), Language.NL, Country.NETHERLANDS,
                         false, false));
 
-        var recordViewCreate = new StepStatistic(Step.HARVEST_ZIP, Status.SUCCESS, 5);
-        var recordViewExternal = new StepStatistic(Step.VALIDATE_EXTERNAL, Status.SUCCESS, 5);
-        var recordViewClose = new StepStatistic(Step.CLOSE, Status.SUCCESS, 5);
+        var recordViewCreate = new StepStatistic(Step.HARVEST_ZIP, Status.SUCCESS, 5L);
+        var recordViewExternal = new StepStatistic(Step.VALIDATE_EXTERNAL, Status.SUCCESS, 5L);
+        var recordViewClose = new StepStatistic(Step.CLOSE, Status.SUCCESS, 5L);
 
         when(datasetRepository.findById(1)).thenReturn(Optional.of(dataset));
         when(recordLogRepository.getStepStatistics("1")).thenReturn(
@@ -149,7 +149,7 @@ class DatasetReportServiceImplTest {
 
     @Test
     void getReportCompletedAllErrors_expectSuccess() {
-        var dataset = new DatasetEntity("dataset", 5, Language.NL, Country.NETHERLANDS, false);
+        var dataset = new DatasetEntity("dataset", 5L, Language.NL, Country.NETHERLANDS, false);
         var message1 = "cvc-complex-type.4: Attribute 'resource' must appear on element 'edm:object'.";
         var message2 = "cvc-complex-type.2.4.b: The content of element 'edm:ProvidedCHO' is not complete.";
         var error1 = new ErrorInfoDto(message1, Status.FAIL, List.of("1 | providerId1 | europeanaId1", "2 | providerId2 | europeanaId2"));
@@ -159,13 +159,13 @@ class DatasetReportServiceImplTest {
         var externalProgress = new ProgressByStepDto(Step.VALIDATE_EXTERNAL, 0, 5, 0, errors);
 
         var report = new ProgressInfoDto(
-                "All dataset records failed to be processed.", 5, 5L,
+                "All dataset records failed to be processed.", 5L, 5L,
                 List.of(createProgress, externalProgress),
                 new DatasetInfoDto("", "", LocalDateTime.now(), Language.NL, Country.NETHERLANDS,
                         false, false));
 
-        var recordViewCreate = new StepStatistic(Step.HARVEST_ZIP, Status.SUCCESS, 5);
-        var recordViewExternal = new StepStatistic(Step.VALIDATE_EXTERNAL, Status.FAIL, 5);
+        var recordViewCreate = new StepStatistic(Step.HARVEST_ZIP, Status.SUCCESS, 5L);
+        var recordViewExternal = new StepStatistic(Step.VALIDATE_EXTERNAL, Status.FAIL, 5L);
 
         var errorView1 = new ErrorLogViewImpl(1L, getTestRecordEntity(1L), Step.VALIDATE_EXTERNAL, Status.FAIL,
                 "cvc-complex-type.4: Attribute 'resource' must appear on element 'edm:object'.");
@@ -191,13 +191,13 @@ class DatasetReportServiceImplTest {
 
     @Test
     void getReport_retrieveEmptyDataset_expectSuccess() {
-        var datasetEntity = new DatasetEntity("test", 0, Language.NL, Country.NETHERLANDS, false);
+        var datasetEntity = new DatasetEntity("test", 0L, Language.NL, Country.NETHERLANDS, false);
         datasetEntity.setDatasetId(1);
         when(datasetRepository.findById(1)).thenReturn(Optional.of(datasetEntity));
         when(recordLogRepository.getStepStatistics("1")).thenReturn(List.of());
 
         var expected = new ProgressInfoDto(
-                "Dataset is empty.", 0, 0L, List.of(),
+                "Dataset is empty.", 0L, 0L, List.of(),
                 new DatasetInfoDto("", "", LocalDateTime.now(), null, null, false, false));
         var report = service.getReport("1");
         assertReportEquals(expected, report);
@@ -213,7 +213,7 @@ class DatasetReportServiceImplTest {
 
     @Test
     void getReport_failToRetrieveRecords_expectFail() {
-        when(datasetRepository.findById(1)).thenReturn(Optional.of(new DatasetEntity("test", 5, Language.NL, Country.NETHERLANDS, false)));
+        when(datasetRepository.findById(1)).thenReturn(Optional.of(new DatasetEntity("test", 5L, Language.NL, Country.NETHERLANDS, false)));
         when(recordLogRepository.getStepStatistics("1")).thenThrow(new RuntimeException("exception"));
 
         assertThrows(ServiceException.class, () -> service.getReport("1"));
@@ -226,13 +226,13 @@ class DatasetReportServiceImplTest {
 
     @Test
     void getReport_HarvestingDataset_expectSuccess() {
-        var datasetEntity = new DatasetEntity("test", -1, Language.NL, Country.NETHERLANDS, false);
+        var datasetEntity = new DatasetEntity("test", null, Language.NL, Country.NETHERLANDS, false);
         datasetEntity.setDatasetId(1);
         when(datasetRepository.findById(1)).thenReturn(Optional.of(datasetEntity));
         when(recordLogRepository.getStepStatistics("1")).thenReturn(List.of());
 
         var expected = new ProgressInfoDto(
-            "Harvesting dataset identifiers and records.", -1, 0L, List.of(),
+            "Harvesting dataset identifiers and records.", null, 0L, List.of(),
             new DatasetInfoDto("", "", LocalDateTime.now(), null, null, false, false));
         var report = service.getReport("1");
 

--- a/src/test/java/eu/europeana/metis/sandbox/service/dataset/DatasetReportServiceImplTest.java
+++ b/src/test/java/eu/europeana/metis/sandbox/service/dataset/DatasetReportServiceImplTest.java
@@ -66,7 +66,7 @@ class DatasetReportServiceImplTest {
         var createProgress = new ProgressByStepDto(Step.HARVEST_ZIP, 5, 0, 0, List.of());
         var externalProgress = new ProgressByStepDto(Step.VALIDATE_EXTERNAL, 1, 4, 0, errors);
         var report = new ProgressInfoDto(
-                "A review URL will be generated when the dataset has finished processing",
+                "A review URL will be generated when the dataset has finished processing.",
                 5, 4L,
                 List.of(createProgress, externalProgress),
                 new DatasetInfoDto("", "", LocalDateTime.now(), Language.NL, Country.NETHERLANDS,
@@ -101,7 +101,7 @@ class DatasetReportServiceImplTest {
         var createProgress = new ProgressByStepDto(Step.HARVEST_ZIP, 5, 0, 0, List.of());
         var externalProgress = new ProgressByStepDto(Step.VALIDATE_EXTERNAL, 5, 0, 0, List.of());
         var report = new ProgressInfoDto(
-                "A review URL will be generated when the dataset has finished processing",
+                "A review URL will be generated when the dataset has finished processing.",
                 5, 0L,
                 List.of(createProgress, externalProgress),
                 new DatasetInfoDto("", "", LocalDateTime.now(), null, null, false, false));
@@ -159,7 +159,7 @@ class DatasetReportServiceImplTest {
         var externalProgress = new ProgressByStepDto(Step.VALIDATE_EXTERNAL, 0, 5, 0, errors);
 
         var report = new ProgressInfoDto(
-                "All dataset records failed to be processed", 5, 5L,
+                "All dataset records failed to be processed.", 5, 5L,
                 List.of(createProgress, externalProgress),
                 new DatasetInfoDto("", "", LocalDateTime.now(), Language.NL, Country.NETHERLANDS,
                         false, false));
@@ -197,7 +197,7 @@ class DatasetReportServiceImplTest {
         when(recordLogRepository.getStepStatistics("1")).thenReturn(List.of());
 
         var expected = new ProgressInfoDto(
-                "Dataset is empty", 0, 0L, List.of(),
+                "Dataset is empty.", 0, 0L, List.of(),
                 new DatasetInfoDto("", "", LocalDateTime.now(), null, null, false, false));
         var report = service.getReport("1");
         assertReportEquals(expected, report);
@@ -222,6 +222,21 @@ class DatasetReportServiceImplTest {
     @Test
     void getReport_nullDatasetId_expectFail() {
         assertThrows(NullPointerException.class, () -> service.getReport(null));
+    }
+
+    @Test
+    void getReport_HarvestingDataset_expectSuccess() {
+        var datasetEntity = new DatasetEntity("test", -1, Language.NL, Country.NETHERLANDS, false);
+        datasetEntity.setDatasetId(1);
+        when(datasetRepository.findById(1)).thenReturn(Optional.of(datasetEntity));
+        when(recordLogRepository.getStepStatistics("1")).thenReturn(List.of());
+
+        var expected = new ProgressInfoDto(
+            "Harvesting dataset identifiers and records.", -1, 0L, List.of(),
+            new DatasetInfoDto("", "", LocalDateTime.now(), null, null, false, false));
+        var report = service.getReport("1");
+
+        assertReportEquals(expected, report);
     }
 
     private void assertReportEquals(ProgressInfoDto expected, ProgressInfoDto actual) {

--- a/src/test/java/eu/europeana/metis/sandbox/service/dataset/DatasetServiceImplTest.java
+++ b/src/test/java/eu/europeana/metis/sandbox/service/dataset/DatasetServiceImplTest.java
@@ -123,8 +123,8 @@ class DatasetServiceImplTest {
 
   @Test
   void updateNumberOfTotalRecord_expectSuccess(){
-    service.updateNumberOfTotalRecord("1", 10);
-    verify(datasetRepository).updateRecordsQuantity(1, 10);
+    service.updateNumberOfTotalRecord("1", 10L);
+    verify(datasetRepository).updateRecordsQuantity(1, 10L);
   }
 
   @Test

--- a/src/test/java/eu/europeana/metis/sandbox/service/workflow/HarvestServiceImplTest.java
+++ b/src/test/java/eu/europeana/metis/sandbox/service/workflow/HarvestServiceImplTest.java
@@ -96,7 +96,7 @@ public class HarvestServiceImplTest {
 
     harvestService.harvest(new ByteArrayInputStream(new byte[0]), "datasetId", createMockEncapsulatedRecord());
 
-    assertHarvestProcessWithOutXslt(recordPublishService, 2, Step.HARVEST_ZIP, 2);
+    assertHarvestProcessWithOutXslt(recordPublishService, 2, Step.HARVEST_ZIP, 2L);
   }
 
   @Test
@@ -116,7 +116,7 @@ public class HarvestServiceImplTest {
 
     harvestService.harvest(new ByteArrayInputStream(new byte[0]), "datasetId", createMockEncapsulatedRecord());
 
-    assertHarvestProcessWithOutXslt(recordPublishService, 1, Step.HARVEST_ZIP, 1);
+    assertHarvestProcessWithOutXslt(recordPublishService, 1, Step.HARVEST_ZIP, 1L);
   }
 
   @Test
@@ -136,7 +136,7 @@ public class HarvestServiceImplTest {
 
     harvestService.harvest(new ByteArrayInputStream(new byte[0]), "datasetId", createMockEncapsulatedRecord());
 
-    assertHarvestProcessWithXslt(recordPublishService, 2, Step.HARVEST_ZIP, 2);
+    assertHarvestProcessWithXslt(recordPublishService, 2, Step.HARVEST_ZIP, 2L);
   }
 
   @Test
@@ -156,7 +156,7 @@ public class HarvestServiceImplTest {
 
     harvestService.harvest(new ByteArrayInputStream(new byte[0]), "datasetId", createMockEncapsulatedRecord());
 
-    assertHarvestProcessWithXslt(recordPublishService, 1, Step.HARVEST_ZIP, 1);
+    assertHarvestProcessWithXslt(recordPublishService, 1, Step.HARVEST_ZIP, 1L);
   }
 
   @Test
@@ -188,7 +188,7 @@ public class HarvestServiceImplTest {
 
     harvestService.harvestOaiPmh("datasetId", createMockEncapsulatedRecord(), oaiHarvestData);
 
-    assertHarvestProcessWithOutXslt(recordPublishService, 2, Step.HARVEST_OAI_PMH, 2);
+    assertHarvestProcessWithOutXslt(recordPublishService, 2, Step.HARVEST_OAI_PMH, 2L);
   }
 
   @Test
@@ -211,7 +211,7 @@ public class HarvestServiceImplTest {
 
     harvestService.harvestOaiPmh("datasetId", createMockEncapsulatedRecord(), oaiHarvestData);
 
-    assertHarvestProcessWithOutXslt(recordPublishService, 1, Step.HARVEST_OAI_PMH, 1);
+    assertHarvestProcessWithOutXslt(recordPublishService, 1, Step.HARVEST_OAI_PMH, 1L);
   }
 
   @Test
@@ -234,7 +234,7 @@ public class HarvestServiceImplTest {
 
     harvestService.harvestOaiPmh("datasetId", createMockEncapsulatedRecord(), oaiHarvestData);
 
-    assertHarvestProcessWithXslt(recordPublishService, 2, Step.HARVEST_OAI_PMH, 2);
+    assertHarvestProcessWithXslt(recordPublishService, 2, Step.HARVEST_OAI_PMH, 2L);
   }
 
   @Test
@@ -257,7 +257,7 @@ public class HarvestServiceImplTest {
 
     harvestService.harvestOaiPmh("datasetId", createMockEncapsulatedRecord(), oaiHarvestData);
 
-    assertHarvestProcessWithXslt(recordPublishService, 1, Step.HARVEST_OAI_PMH, 1);
+    assertHarvestProcessWithXslt(recordPublishService, 1, Step.HARVEST_OAI_PMH, 1L);
   }
 
   @Test
@@ -291,7 +291,7 @@ public class HarvestServiceImplTest {
 
     verify(datasetService, times(0)).setRecordLimitExceeded("datasetId");
 
-    assertHarvestProcessWithOutXslt(recordPublishService, 2, Step.HARVEST_OAI_PMH, 2);
+    assertHarvestProcessWithOutXslt(recordPublishService, 2, Step.HARVEST_OAI_PMH, 2L);
   }
 
   @Test
@@ -317,11 +317,11 @@ public class HarvestServiceImplTest {
 
     verify(datasetService, times(0)).setRecordLimitExceeded("datasetId");
 
-    assertHarvestProcessWithXslt(recordPublishService, 2, Step.HARVEST_OAI_PMH, 2);
+    assertHarvestProcessWithXslt(recordPublishService, 2, Step.HARVEST_OAI_PMH, 2L);
   }
 
   private void assertHarvestProcess(RecordPublishService recordPublishService, int times, Step step,
-      int numberOfRecords) {
+      Long numberOfRecords) {
     verify(datasetService).updateNumberOfTotalRecord(eq("datasetId"), eq(numberOfRecords));
     assertTrue(captorRecordInfo.getAllValues().stream().allMatch(x -> x.getRecord().getDatasetId().equals("datasetId")));
     assertTrue(captorRecordInfo.getAllValues().stream().allMatch(x -> x.getRecord().getContent() != null));
@@ -331,13 +331,13 @@ public class HarvestServiceImplTest {
   }
 
   private void assertHarvestProcessWithXslt(RecordPublishService recordPublishService, int times, Step step,
-      int numberOfRecords) {
+      Long numberOfRecords) {
     verify(recordPublishService, times(times)).publishToTransformationToEdmExternalQueue(captorRecordInfo.capture(), eq(step));
     assertHarvestProcess(recordPublishService, times, step, numberOfRecords);
   }
 
   private void assertHarvestProcessWithOutXslt(RecordPublishService recordPublishService, int times, Step step,
-      int numberOfRecords) {
+      Long numberOfRecords) {
     verify(recordPublishService, times(times)).publishToHarvestQueue(captorRecordInfo.capture(), eq(step));
     assertHarvestProcess(recordPublishService, times, step, numberOfRecords);
   }


### PR DESCRIPTION
When stream file or OAI harvest is made the following message is returned.
It performs the gathering of all records in order to provide the total records amount when it changes to in progress.
**harvesting**
```
{
  "status": "harvesting identifiers",
  "portal-publish": "Harvesting dataset identifiers and records.",
  "total-records": 0,
  "processed-records": 0,
  "progress-by-step": [],
  "dataset-info": {
    "dataset-id": "7",
    "dataset-name": "test160320221322",
    "creation-date": "2022-03-16T13:22:46.91253",
    "language": "Dutch",
    "country": "Netherlands",
    "record-limit-exceeded": false,
    "transformed-to-edm-external": false
  }
}
```
**in progress**
```
{
  "status": "in progress",
  "portal-publish": "A review URL will be generated when the dataset has finished processing.",
  "total-records": 285,
  "processed-records": 51,
  "progress-by-step": [
    {
      "step": "harvest OAI-PMH",
      "total": 285,
      "success": 285,
      "fail": 0,
      "warn": 0
    }
...
  "dataset-info": {
    "dataset-id": "7",
    "dataset-name": "test160320221322",
    "creation-date": "2022-03-16T13:22:46.91253",
    "language": "Dutch",
    "country": "Netherlands",
    "record-limit-exceeded": false,
    "transformed-to-edm-external": false
  }
```